### PR TITLE
Capture only gitignored .env files

### DIFF
--- a/src/commands/capture.ts
+++ b/src/commands/capture.ts
@@ -75,7 +75,7 @@ export async function captureCommand(): Promise<void> {
     }
 
     if (envFilePaths.length === 0) {
-      consola.warn("No gitignored .env files found.");
+      consola.warn("No .env files found.");
       return;
     }
 

--- a/src/commands/capture.ts
+++ b/src/commands/capture.ts
@@ -63,12 +63,14 @@ export async function captureCommand(): Promise<void> {
 
     /** Find all env files */
     consola.start("Searching for .env files...");
-    const { files: envFilePaths, skippedTracked } =
-      await findEnvFiles(repoRoot);
+    const { files: envFilePaths, excluded } = await findEnvFiles(repoRoot);
 
-    if (skippedTracked.length > 0) {
+    if (excluded.length > 0) {
+      const preview = excluded.slice(0, 5).join(", ");
+      const more =
+        excluded.length > 5 ? ` (...and ${excluded.length - 5} more)` : "";
       consola.info(
-        `Skipped ${skippedTracked.length} file(s) tracked by git: ${skippedTracked.join(", ")}`,
+        `Skipped ${excluded.length} .env file(s) not in .gitignore: ${preview}${more}`,
       );
     }
 

--- a/src/commands/capture.ts
+++ b/src/commands/capture.ts
@@ -63,10 +63,17 @@ export async function captureCommand(): Promise<void> {
 
     /** Find all env files */
     consola.start("Searching for .env files...");
-    const envFilePaths = await findEnvFiles(repoRoot);
+    const { files: envFilePaths, skippedTracked } =
+      await findEnvFiles(repoRoot);
+
+    if (skippedTracked.length > 0) {
+      consola.info(
+        `Skipped ${skippedTracked.length} file(s) tracked by git: ${skippedTracked.join(", ")}`,
+      );
+    }
 
     if (envFilePaths.length === 0) {
-      consola.warn("No .env files found.");
+      consola.warn("No gitignored .env files found.");
       return;
     }
 

--- a/src/commands/capture.ts
+++ b/src/commands/capture.ts
@@ -70,7 +70,7 @@ export async function captureCommand(): Promise<void> {
       const more =
         excluded.length > 5 ? ` (...and ${excluded.length - 5} more)` : "";
       consola.info(
-        `Skipped ${excluded.length} .env file(s) not in .gitignore: ${preview}${more}`,
+        `Skipped ${excluded.length} .env file(s) not ignored by git: ${preview}${more}`,
       );
     }
 

--- a/src/commands/pack.ts
+++ b/src/commands/pack.ts
@@ -39,10 +39,17 @@ export async function packCommand(): Promise<void> {
 
     /** Find all env files */
     consola.start("Searching for .env files...");
-    const envFilePaths = await findEnvFiles(repoRoot);
+    const { files: envFilePaths, skippedTracked } =
+      await findEnvFiles(repoRoot);
+
+    if (skippedTracked.length > 0) {
+      consola.info(
+        `Skipped ${skippedTracked.length} file(s) tracked by git: ${skippedTracked.join(", ")}`,
+      );
+    }
 
     if (envFilePaths.length === 0) {
-      consola.error("No .env files found in repository.");
+      consola.error("No gitignored .env files found in repository.");
       consola.info("Add some .env files first before packing.");
       process.exit(1);
     }

--- a/src/commands/pack.ts
+++ b/src/commands/pack.ts
@@ -46,7 +46,7 @@ export async function packCommand(): Promise<void> {
       const more =
         excluded.length > 5 ? ` (...and ${excluded.length - 5} more)` : "";
       consola.info(
-        `Skipped ${excluded.length} .env file(s) not in .gitignore: ${preview}${more}`,
+        `Skipped ${excluded.length} .env file(s) not ignored by git: ${preview}${more}`,
       );
     }
 

--- a/src/commands/pack.ts
+++ b/src/commands/pack.ts
@@ -39,12 +39,14 @@ export async function packCommand(): Promise<void> {
 
     /** Find all env files */
     consola.start("Searching for .env files...");
-    const { files: envFilePaths, skippedTracked } =
-      await findEnvFiles(repoRoot);
+    const { files: envFilePaths, excluded } = await findEnvFiles(repoRoot);
 
-    if (skippedTracked.length > 0) {
+    if (excluded.length > 0) {
+      const preview = excluded.slice(0, 5).join(", ");
+      const more =
+        excluded.length > 5 ? ` (...and ${excluded.length - 5} more)` : "";
       consola.info(
-        `Skipped ${skippedTracked.length} file(s) tracked by git: ${skippedTracked.join(", ")}`,
+        `Skipped ${excluded.length} .env file(s) not in .gitignore: ${preview}${more}`,
       );
     }
 

--- a/src/commands/pack.ts
+++ b/src/commands/pack.ts
@@ -51,7 +51,7 @@ export async function packCommand(): Promise<void> {
     }
 
     if (envFilePaths.length === 0) {
-      consola.error("No gitignored .env files found in repository.");
+      consola.error("No .env files found in repository.");
       consola.info("Add some .env files first before packing.");
       process.exit(1);
     }

--- a/src/lib/git.test.ts
+++ b/src/lib/git.test.ts
@@ -1,10 +1,10 @@
 import { existsSync } from "node:fs";
+import { execa } from "execa";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { isGitRepo } from "./git";
+import { filterGitIgnoredFiles, isGitRepo } from "./git";
 
 vi.mock("node:fs");
-vi.mock("node:child_process");
-vi.mock("node:util");
+vi.mock("execa");
 
 describe("git", () => {
   beforeEach(() => {
@@ -26,6 +26,64 @@ describe("git", () => {
       const result = isGitRepo("/project");
 
       expect(result).toBe(false);
+    });
+  });
+
+  describe("filterGitIgnoredFiles", () => {
+    it("returns empty array without invoking git when given no paths", async () => {
+      const result = await filterGitIgnoredFiles("/project", []);
+
+      expect(result).toEqual([]);
+      expect(execa).not.toHaveBeenCalled();
+    });
+
+    it("returns the subset git reports as ignored", async () => {
+      vi.mocked(execa).mockResolvedValue({
+        exitCode: 0,
+        stdout: [".env", "apps/web/.env.local"].join("\0"),
+        stderr: "",
+      } as never);
+
+      const result = await filterGitIgnoredFiles("/project", [
+        ".env",
+        ".env.shared",
+        "apps/web/.env.local",
+      ]);
+
+      expect(result).toEqual([".env", "apps/web/.env.local"]);
+      expect(execa).toHaveBeenCalledWith(
+        "git",
+        ["check-ignore", "--stdin", "-z"],
+        expect.objectContaining({
+          cwd: "/project",
+          input: [".env", ".env.shared", "apps/web/.env.local"].join("\0"),
+          reject: false,
+        }),
+      );
+    });
+
+    it("returns an empty array when git exits 1 (no paths matched)", async () => {
+      vi.mocked(execa).mockResolvedValue({
+        exitCode: 1,
+        stdout: "",
+        stderr: "",
+      } as never);
+
+      const result = await filterGitIgnoredFiles("/project", [".env.shared"]);
+
+      expect(result).toEqual([]);
+    });
+
+    it("throws when git exits with a real error code", async () => {
+      vi.mocked(execa).mockResolvedValue({
+        exitCode: 128,
+        stdout: "",
+        stderr: "fatal: not a git repository",
+      } as never);
+
+      await expect(filterGitIgnoredFiles("/project", [".env"])).rejects.toThrow(
+        /not a git repository/,
+      );
     });
   });
 });

--- a/src/lib/git.ts
+++ b/src/lib/git.ts
@@ -13,6 +13,52 @@ export function isGitRepo(dir: string): boolean {
 }
 
 /**
+ * Filter a list of paths to only those git considers ignored
+ *
+ * Uses `git check-ignore` so all gitignore semantics are honored: nested
+ * `.gitignore` files, repo-local `.git/info/exclude`, the user's global ignore
+ * file, and negation rules. Tracked files (including those added with `git add
+ * -f`) are NOT reported as ignored, which is what we want.
+ *
+ * @param repoRoot - Absolute path to the git repository root
+ * @param paths - Paths relative to `repoRoot` to check
+ * @returns Subset of `paths` that git considers ignored, in the same order
+ */
+export async function filterGitIgnoredFiles(
+  repoRoot: string,
+  paths: string[],
+): Promise<string[]> {
+  if (paths.length === 0) {
+    return [];
+  }
+
+  const result = await execa("git", ["check-ignore", "--stdin", "-z"], {
+    cwd: repoRoot,
+    input: paths.join("\0"),
+    reject: false,
+  });
+
+  /**
+   * Exit code 1 means "no paths matched" — not an error. Anything else non-zero
+   * is a real failure (e.g. not a git repo, git missing).
+   */
+  if (result.exitCode === 1) {
+    return [];
+  }
+  if (result.exitCode !== 0) {
+    throw new Error(
+      `git check-ignore failed (exit ${result.exitCode}): ${result.stderr}`,
+    );
+  }
+
+  const ignored = new Set(
+    result.stdout.split("\0").filter((path) => path.length > 0),
+  );
+
+  return paths.filter((path) => ignored.has(path));
+}
+
+/**
  * Initialize a git repository
  *
  * @param dir - Directory to initialize

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -16,6 +16,7 @@ export {
   addRemote,
   commitAndPush,
   createInitialCommit,
+  filterGitIgnoredFiles,
   initialCommitAndPush,
   initGitRepo,
   isGitRepo,

--- a/src/utils/find-env-files.integration.test.ts
+++ b/src/utils/find-env-files.integration.test.ts
@@ -1,0 +1,97 @@
+import { execa } from "execa";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { findEnvFiles } from "./find-env-files";
+
+/**
+ * Exercises `findEnvFiles` against a real git repo with nested `.gitignore`s.
+ * This is what verifies the contract between our code and `git check-ignore` —
+ * the unit tests above only check our own logic and could miss a regression in
+ * argv framing, NUL handling, or exit-code interpretation.
+ */
+describe("findEnvFiles (integration)", () => {
+  let repoRoot: string;
+
+  beforeAll(async () => {
+    repoRoot = mkdtempSync(join(tmpdir(), "envi-find-env-files-"));
+
+    await execa("git", ["init", "-q"], { cwd: repoRoot });
+    await execa("git", ["config", "user.email", "test@example.com"], {
+      cwd: repoRoot,
+    });
+    await execa("git", ["config", "user.name", "Test"], { cwd: repoRoot });
+
+    /** Root: ignore `.env`, but allow `.env.shared` */
+    writeFileSync(join(repoRoot, ".gitignore"), ".env\n");
+    writeFileSync(join(repoRoot, ".env"), "ROOT_SECRET=1\n");
+    writeFileSync(join(repoRoot, ".env.shared"), "ROOT_SHARED=1\n");
+
+    /** Apps/web: nested .gitignore adds `.env.local` */
+    mkdirSync(join(repoRoot, "apps/web"), { recursive: true });
+    writeFileSync(join(repoRoot, "apps/web/.gitignore"), ".env.local\n");
+    writeFileSync(join(repoRoot, "apps/web/.env.local"), "WEB_SECRET=1\n");
+    writeFileSync(join(repoRoot, "apps/web/.env"), "WEB_PUBLIC=1\n");
+
+    /** Packages/api: no nested .gitignore — `.env` here matches root rule */
+    mkdirSync(join(repoRoot, "packages/api"), { recursive: true });
+    writeFileSync(join(repoRoot, "packages/api/.env"), "API_SECRET=1\n");
+    writeFileSync(
+      join(repoRoot, "packages/api/.env.example"),
+      "API_EXAMPLE=1\n",
+    );
+
+    /** Track everything that isn't gitignored */
+    await execa(
+      "git",
+      ["add", ".gitignore", ".env.shared", "apps/web", "packages/api"],
+      { cwd: repoRoot },
+    );
+    await execa("git", ["commit", "-q", "-m", "init"], { cwd: repoRoot });
+  });
+
+  afterAll(() => {
+    rmSync(repoRoot, { recursive: true, force: true });
+  });
+
+  it("captures gitignored files and excludes everything else", async () => {
+    const result = await findEnvFiles(repoRoot);
+
+    expect(result.files.sort()).toEqual([
+      ".env",
+      "apps/web/.env",
+      "apps/web/.env.local",
+      "packages/api/.env",
+    ]);
+    expect(result.excluded.sort()).toEqual([
+      ".env.shared",
+      "packages/api/.env.example",
+    ]);
+  });
+
+  it("excludes a file that has been force-added", async () => {
+    /**
+     * Force-add the root `.env` despite the ignore rule. It is now tracked, so
+     * `git check-ignore` no longer reports it as ignored and `findEnvFiles`
+     * must not capture it.
+     */
+    await execa("git", ["add", "-f", ".env"], { cwd: repoRoot });
+    await execa("git", ["commit", "-q", "-m", "force-add .env"], {
+      cwd: repoRoot,
+    });
+
+    try {
+      const result = await findEnvFiles(repoRoot);
+
+      expect(result.files).not.toContain(".env");
+      expect(result.excluded).toContain(".env");
+    } finally {
+      /** Restore prior state for any later test in this block */
+      await execa("git", ["rm", "--cached", ".env"], { cwd: repoRoot });
+      await execa("git", ["commit", "-q", "-m", "untrack .env"], {
+        cwd: repoRoot,
+      });
+    }
+  });
+});

--- a/src/utils/find-env-files.test.ts
+++ b/src/utils/find-env-files.test.ts
@@ -1,3 +1,4 @@
+import { consola } from "consola";
 import fg from "fast-glob";
 import { existsSync } from "node:fs";
 import { beforeEach, describe, expect, it, vi } from "vitest";
@@ -34,10 +35,10 @@ describe("findEnvFiles", () => {
       const result = await findEnvFiles("/project");
 
       expect(result.files).toEqual([".env", "apps/web/.env.local"]);
-      expect(result.skippedTracked).toEqual([".env.shared"]);
+      expect(result.excluded).toEqual([".env.shared"]);
     });
 
-    it("reports no skipped files when every candidate is ignored", async () => {
+    it("reports no excluded files when every candidate is ignored", async () => {
       vi.mocked(fg).mockResolvedValue([".env", ".env.local"]);
       vi.mocked(filterGitIgnoredFiles).mockResolvedValue([
         ".env",
@@ -47,13 +48,13 @@ describe("findEnvFiles", () => {
       const result = await findEnvFiles("/project");
 
       expect(result.files).toEqual([".env", ".env.local"]);
-      expect(result.skippedTracked).toEqual([]);
+      expect(result.excluded).toEqual([]);
     });
 
     it("excludes force-added files (tracked, even if matching .gitignore)", async () => {
       /**
        * `git add -f .env` makes a file tracked, so `git check-ignore` does NOT
-       * report it as ignored — it should land in skippedTracked.
+       * report it as ignored — it should land in `excluded`.
        */
       vi.mocked(fg).mockResolvedValue([".env", "apps/api/.env"]);
       vi.mocked(filterGitIgnoredFiles).mockResolvedValue(["apps/api/.env"]);
@@ -61,7 +62,40 @@ describe("findEnvFiles", () => {
       const result = await findEnvFiles("/project");
 
       expect(result.files).toEqual(["apps/api/.env"]);
-      expect(result.skippedTracked).toEqual([".env"]);
+      expect(result.excluded).toEqual([".env"]);
+    });
+
+    it("excludes untracked files that are not covered by a gitignore rule", async () => {
+      /**
+       * A new `.env` in a fresh dir without a matching ignore rule is neither
+       * tracked nor ignored — git check-ignore returns nothing for it. It must
+       * NOT be captured (the user might be about to commit it) but should land
+       * in `excluded` so they know why it was skipped.
+       */
+      vi.mocked(fg).mockResolvedValue([".env", "new-dir/.env"]);
+      vi.mocked(filterGitIgnoredFiles).mockResolvedValue([".env"]);
+
+      const result = await findEnvFiles("/project");
+
+      expect(result.files).toEqual([".env"]);
+      expect(result.excluded).toEqual(["new-dir/.env"]);
+    });
+
+    it("falls back to capturing all candidates when git check-ignore fails", async () => {
+      vi.mocked(fg).mockResolvedValue([".env", "apps/web/.env.local"]);
+      vi.mocked(filterGitIgnoredFiles).mockRejectedValue(
+        new Error("spawn git ENOENT"),
+      );
+      const warn = vi.spyOn(consola, "warn").mockImplementation(() => {});
+
+      const result = await findEnvFiles("/project");
+
+      expect(result.files).toEqual([".env", "apps/web/.env.local"]);
+      expect(result.excluded).toEqual([]);
+      expect(warn).toHaveBeenCalledWith(
+        expect.stringContaining("spawn git ENOENT"),
+      );
+      warn.mockRestore();
     });
 
     it("passes only the performance ignore patterns to fast-glob", async () => {
@@ -89,24 +123,37 @@ describe("findEnvFiles", () => {
       const result = await findEnvFiles("/project");
 
       expect(result.files).toEqual([".env", "apps/web/.env.local"]);
-      expect(result.skippedTracked).toEqual([]);
+      expect(result.excluded).toEqual([]);
       expect(filterGitIgnoredFiles).not.toHaveBeenCalled();
     });
 
-    it("still skips directories listed in a top-level .gitignore", async () => {
+    it("treats plain entries in a top-level .gitignore as directory patterns", async () => {
       vi.mocked(existsSync).mockReturnValue(true);
       const { readFileSync } = await import("node:fs");
       vi.mocked(readFileSync).mockReturnValue(
-        "node_modules\nbuild_output\n.env.local\n# comment\n" as never,
+        [
+          "node_modules",
+          "build_output",
+          ".cache",
+          "apps.dist/",
+          "*.log",
+          "!important",
+          "# comment",
+          "",
+        ].join("\n") as never,
       );
       vi.mocked(fg).mockResolvedValue([".env"]);
 
       await findEnvFiles("/project");
 
       const options = vi.mocked(fg).mock.calls[0]?.[1];
+      /** Plain entries (with or without a trailing slash) become dir patterns */
       expect(options?.ignore).toContain("**/build_output/**");
-      /** File-level patterns must not be added — we still want to find them */
-      expect(options?.ignore).not.toContain("**/.env.local/**");
+      expect(options?.ignore).toContain("**/.cache/**");
+      expect(options?.ignore).toContain("**/apps.dist/**");
+      /** Glob patterns and negations are skipped — full ignore engine needed */
+      expect(options?.ignore).not.toContain("**/*.log/**");
+      expect(options?.ignore).not.toContain("**/!important/**");
     });
   });
 });

--- a/src/utils/find-env-files.test.ts
+++ b/src/utils/find-env-files.test.ts
@@ -1,116 +1,112 @@
 import fg from "fast-glob";
 import { existsSync } from "node:fs";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { filterGitIgnoredFiles, isGitRepo } from "~/lib/git";
 import { findEnvFiles } from "./find-env-files.js";
 
 vi.mock("fast-glob");
 vi.mock("node:fs");
-vi.mock("ignore");
+vi.mock("~/lib/git");
 
 describe("findEnvFiles", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-  });
-
-  it("should find .env file in root and subdirectories", async () => {
-    const repoRoot = "/project";
-    vi.mocked(existsSync).mockReturnValue(false); // No .gitignore
-    vi.mocked(fg).mockResolvedValue([".env"]);
-
-    const result = await findEnvFiles(repoRoot);
-
-    expect(result).toEqual([".env"]);
-    expect(fg).toHaveBeenCalledWith(
-      [".env", ".env.*", "**/.env", "**/.env.*"],
-      expect.objectContaining({
-        cwd: repoRoot,
-        dot: true,
-        absolute: false,
-        ignore: expect.arrayContaining([
-          "node_modules/**",
-          ".git/**",
-          "dist/**",
-          "build/**",
-        ]),
-      }),
-    );
-  });
-
-  it("should find .env.* files recursively", async () => {
-    const repoRoot = "/project";
+    /** Default: no gitignore on disk */
     vi.mocked(existsSync).mockReturnValue(false);
-    vi.mocked(fg).mockResolvedValue([
-      ".env.local",
-      ".env.production",
-      ".env.development",
-    ]);
-
-    const result = await findEnvFiles(repoRoot);
-
-    expect(result).toEqual([
-      ".env.local",
-      ".env.production",
-      ".env.development",
-    ]);
   });
 
-  it("should find nested env files in subdirectories", async () => {
-    const repoRoot = "/project";
-    vi.mocked(existsSync).mockReturnValue(false);
-    vi.mocked(fg).mockResolvedValue([
-      ".env",
-      "apps/web/.env.local",
-      "packages/api/.env",
-      "services/fns/.env.stafftraveler",
-    ]);
+  describe("in a git repository", () => {
+    beforeEach(() => {
+      vi.mocked(isGitRepo).mockReturnValue(true);
+    });
 
-    const result = await findEnvFiles(repoRoot);
+    it("returns only files git considers ignored", async () => {
+      vi.mocked(fg).mockResolvedValue([
+        ".env",
+        ".env.shared",
+        "apps/web/.env.local",
+      ]);
+      vi.mocked(filterGitIgnoredFiles).mockResolvedValue([
+        ".env",
+        "apps/web/.env.local",
+      ]);
 
-    expect(result).toEqual([
-      ".env",
-      "apps/web/.env.local",
-      "packages/api/.env",
-      "services/fns/.env.stafftraveler",
-    ]);
+      const result = await findEnvFiles("/project");
+
+      expect(result.files).toEqual([".env", "apps/web/.env.local"]);
+      expect(result.skippedTracked).toEqual([".env.shared"]);
+    });
+
+    it("reports no skipped files when every candidate is ignored", async () => {
+      vi.mocked(fg).mockResolvedValue([".env", ".env.local"]);
+      vi.mocked(filterGitIgnoredFiles).mockResolvedValue([
+        ".env",
+        ".env.local",
+      ]);
+
+      const result = await findEnvFiles("/project");
+
+      expect(result.files).toEqual([".env", ".env.local"]);
+      expect(result.skippedTracked).toEqual([]);
+    });
+
+    it("excludes force-added files (tracked, even if matching .gitignore)", async () => {
+      /**
+       * `git add -f .env` makes a file tracked, so `git check-ignore` does NOT
+       * report it as ignored — it should land in skippedTracked.
+       */
+      vi.mocked(fg).mockResolvedValue([".env", "apps/api/.env"]);
+      vi.mocked(filterGitIgnoredFiles).mockResolvedValue(["apps/api/.env"]);
+
+      const result = await findEnvFiles("/project");
+
+      expect(result.files).toEqual(["apps/api/.env"]);
+      expect(result.skippedTracked).toEqual([".env"]);
+    });
+
+    it("passes only the performance ignore patterns to fast-glob", async () => {
+      vi.mocked(fg).mockResolvedValue([]);
+      vi.mocked(filterGitIgnoredFiles).mockResolvedValue([]);
+
+      await findEnvFiles("/project");
+
+      const options = vi.mocked(fg).mock.calls[0]?.[1];
+      expect(options?.ignore).toContain("node_modules/**");
+      expect(options?.ignore).toContain(".git/**");
+      /** No .gitignore-derived patterns when in a git repo */
+      expect(existsSync).not.toHaveBeenCalled();
+    });
   });
 
-  it("should include default ignore patterns when no gitignore", async () => {
-    const repoRoot = "/project";
+  describe("outside a git repository", () => {
+    beforeEach(() => {
+      vi.mocked(isGitRepo).mockReturnValue(false);
+    });
 
-    vi.mocked(existsSync).mockReturnValue(false); // No .gitignore
-    vi.mocked(fg).mockResolvedValue([".env"]);
+    it("returns every matched file without invoking the git filter", async () => {
+      vi.mocked(fg).mockResolvedValue([".env", "apps/web/.env.local"]);
 
-    await findEnvFiles(repoRoot);
+      const result = await findEnvFiles("/project");
 
-    const call = vi.mocked(fg).mock.calls[0];
-    const options = call?.[1];
+      expect(result.files).toEqual([".env", "apps/web/.env.local"]);
+      expect(result.skippedTracked).toEqual([]);
+      expect(filterGitIgnoredFiles).not.toHaveBeenCalled();
+    });
 
-    /** Should include all default patterns */
-    expect(options?.ignore).toContain("node_modules/**");
-    expect(options?.ignore).toContain(".git/**");
-    expect(options?.ignore).toContain("dist/**");
-    expect(options?.ignore).toContain("build/**");
-    expect(options?.ignore).toContain(".next/**");
-    expect(options?.ignore).toContain(".turbo/**");
-  });
+    it("still skips directories listed in a top-level .gitignore", async () => {
+      vi.mocked(existsSync).mockReturnValue(true);
+      const { readFileSync } = await import("node:fs");
+      vi.mocked(readFileSync).mockReturnValue(
+        "node_modules\nbuild_output\n.env.local\n# comment\n" as never,
+      );
+      vi.mocked(fg).mockResolvedValue([".env"]);
 
-  it("should handle missing .gitignore gracefully", async () => {
-    const repoRoot = "/project";
-    vi.mocked(existsSync).mockReturnValue(false);
-    vi.mocked(fg).mockResolvedValue([".env"]);
+      await findEnvFiles("/project");
 
-    await findEnvFiles(repoRoot);
-
-    expect(fg).toHaveBeenCalledWith(
-      expect.any(Array),
-      expect.objectContaining({
-        ignore: expect.arrayContaining([
-          "node_modules/**",
-          ".git/**",
-          "dist/**",
-          "build/**",
-        ]),
-      }),
-    );
+      const options = vi.mocked(fg).mock.calls[0]?.[1];
+      expect(options?.ignore).toContain("**/build_output/**");
+      /** File-level patterns must not be added — we still want to find them */
+      expect(options?.ignore).not.toContain("**/.env.local/**");
+    });
   });
 });

--- a/src/utils/find-env-files.ts
+++ b/src/utils/find-env-files.ts
@@ -1,8 +1,12 @@
 import fg from "fast-glob";
 import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
+import { filterGitIgnoredFiles, isGitRepo } from "~/lib/git";
 
-/** Default directories to always ignore */
+/**
+ * Default directories to always skip while globbing (performance, not
+ * semantics)
+ */
 const DEFAULT_IGNORE_PATTERNS = [
   "node_modules/**",
   ".git/**",
@@ -16,101 +20,92 @@ const DEFAULT_IGNORE_PATTERNS = [
   ".turbo/**",
 ];
 
-/**
- * Parse .gitignore file and return directory ignore patterns
- *
- * Only returns directory patterns, not file patterns, since we want to find env
- * files even if they're in .gitignore
- *
- * @param repoRoot - Absolute path to repository root
- * @returns Array of directory ignore patterns from .gitignore
- */
-function parseGitignore(repoRoot: string): string[] {
-  const gitignorePath = join(repoRoot, ".gitignore");
+export interface FindEnvFilesResult {
+  /** Paths (relative to repo root) Envi should capture */
+  files: string[];
+  /**
+   * Paths that matched the glob but are tracked by git (or otherwise not
+   * ignored). They are excluded from `files` because committing them to the
+   * Envi store would shadow the version-controlled copy.
+   */
+  skippedTracked: string[];
+}
 
+/**
+ * Parse a root `.gitignore` for top-level directory patterns only
+ *
+ * Used as a best-effort fallback when the project is not a git repo, so the
+ * glob does not descend into directories the user has marked as ignored (e.g.
+ * custom build outputs). File-level patterns are skipped because we still want
+ * to discover `.env` files that match them.
+ */
+function parseGitignoreDirsFallback(repoRoot: string): string[] {
+  const gitignorePath = join(repoRoot, ".gitignore");
   if (!existsSync(gitignorePath)) {
     return [];
   }
 
   try {
-    const gitignoreContent = readFileSync(gitignorePath, "utf-8");
-    const lines = gitignoreContent.split("\n");
+    const lines = readFileSync(gitignorePath, "utf-8").split("\n");
     const patterns: string[] = [];
 
     for (const line of lines) {
       const trimmed = line.trim();
+      if (trimmed === "" || trimmed.startsWith("#")) continue;
+      if (trimmed.includes(".")) continue;
 
-      /** Skip empty lines and comments */
-      if (trimmed === "" || trimmed.startsWith("#")) {
-        continue;
-      }
-
-      /**
-       * Skip file patterns (containing dots like .env or .env.*) We only want
-       * directory patterns to avoid searching in ignored directories
-       */
-      if (trimmed.includes(".")) {
-        continue;
-      }
-
-      /** Convert gitignore patterns to glob patterns */
       let pattern = trimmed;
-
-      /** If pattern doesn't start with /, it applies to all directories */
-      if (!pattern.startsWith("/")) {
-        pattern = `**/${pattern}`;
+      if (pattern.startsWith("/")) {
+        pattern = pattern.substring(1);
       } else {
-        pattern = pattern.substring(1); // Remove leading /
+        pattern = `**/${pattern}`;
       }
-
-      /** Ensure directory patterns have /** */
       if (!pattern.endsWith("/**")) {
         pattern = `${pattern}/**`;
       }
-
       patterns.push(pattern);
     }
 
     return patterns;
   } catch {
-    /** If reading .gitignore fails, return empty array */
     return [];
   }
 }
 
 /**
- * Find all .env files in a directory
+ * Find `.env` and `.env.*` files Envi should capture.
  *
- * Matches:
- *
- * - `.env` (exact match)
- * - `.env.*` (anything starting with .env. like .env.local, .env.production)
- *
- * Respects .gitignore if present, otherwise uses default ignore list
+ * In a git repository, only files that git considers ignored are returned.
+ * Tracked files (including those added with `git add -f`) are placed in
+ * `skippedTracked` so the caller can surface them. Outside a git repository,
+ * all matched files are returned.
  *
  * @param repoRoot - Absolute path to repository root
- * @returns Array of relative paths from repo root
  */
-export async function findEnvFiles(repoRoot: string): Promise<string[]> {
-  const patterns = [
-    ".env", // Exact match for .env in root
-    ".env.*", // Match .env.* in root
-    "**/.env", // Exact match for .env in subdirectories
-    "**/.env.*", // Match .env.* in subdirectories
-  ];
+export async function findEnvFiles(
+  repoRoot: string,
+): Promise<FindEnvFilesResult> {
+  const patterns = [".env", ".env.*", "**/.env", "**/.env.*"];
 
-  /** Get gitignore patterns */
-  const gitignorePatterns = parseGitignore(repoRoot);
+  const inGitRepo = isGitRepo(repoRoot);
+  const ignorePatterns = inGitRepo
+    ? DEFAULT_IGNORE_PATTERNS
+    : [...DEFAULT_IGNORE_PATTERNS, ...parseGitignoreDirsFallback(repoRoot)];
 
-  /** Combine default ignore patterns with gitignore patterns */
-  const ignorePatterns = [...DEFAULT_IGNORE_PATTERNS, ...gitignorePatterns];
-
-  const files = await fg(patterns, {
+  const candidates = await fg(patterns, {
     cwd: repoRoot,
-    dot: true, // Include dotfiles
-    absolute: false, // Return relative paths
+    dot: true,
+    absolute: false,
     ignore: ignorePatterns,
   });
 
-  return files;
+  if (!inGitRepo) {
+    return { files: candidates, skippedTracked: [] };
+  }
+
+  const ignored = await filterGitIgnoredFiles(repoRoot, candidates);
+  const ignoredSet = new Set(ignored);
+  const skippedTracked = candidates.filter((path) => !ignoredSet.has(path));
+
+  return { files: ignored, skippedTracked };
 }

--- a/src/utils/find-env-files.ts
+++ b/src/utils/find-env-files.ts
@@ -1,7 +1,9 @@
+import { consola } from "consola";
 import fg from "fast-glob";
 import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import { filterGitIgnoredFiles, isGitRepo } from "~/lib/git";
+import { getErrorMessage } from "./get-error-message";
 
 /**
  * Default directories to always skip while globbing (performance, not
@@ -24,20 +26,27 @@ export interface FindEnvFilesResult {
   /** Paths (relative to repo root) Envi should capture */
   files: string[];
   /**
-   * Paths that matched the glob but are tracked by git (or otherwise not
-   * ignored). They are excluded from `files` because committing them to the
-   * Envi store would shadow the version-controlled copy.
+   * Paths that matched the glob but are not gitignored — either tracked or
+   * simply not covered by any ignore rule. They are excluded from `files`
+   * because committing them to the Envi store would shadow the
+   * version-controlled copy or capture a file the user is about to add.
    */
-  skippedTracked: string[];
+  excluded: string[];
 }
 
 /**
- * Parse a root `.gitignore` for top-level directory patterns only
+ * Parse a root `.gitignore` for directory ignore patterns
  *
- * Used as a best-effort fallback when the project is not a git repo, so the
- * glob does not descend into directories the user has marked as ignored (e.g.
- * custom build outputs). File-level patterns are skipped because we still want
- * to discover `.env` files that match them.
+ * Used as a best-effort fallback when the project is not a git repo (or `git
+ * check-ignore` fails) so the glob does not descend into directories the user
+ * has marked as ignored — `.cache/`, `.turbo/`, custom build outputs, etc.
+ * Negation and glob patterns are skipped because they need a full ignore engine
+ * to honor correctly.
+ *
+ * Plain entries are treated as directory patterns. That is safe even if a
+ * user's `.gitignore` line refers to a file, because the resulting `**\/foo/**`
+ * pattern only matches paths nested inside a `foo` dir, not a file named
+ * `foo`.
  */
 function parseGitignoreDirsFallback(repoRoot: string): string[] {
   const gitignorePath = join(repoRoot, ".gitignore");
@@ -52,18 +61,21 @@ function parseGitignoreDirsFallback(repoRoot: string): string[] {
     for (const line of lines) {
       const trimmed = line.trim();
       if (trimmed === "" || trimmed.startsWith("#")) continue;
-      if (trimmed.includes(".")) continue;
+      /** Skip negations — would need a real ignore engine to honor */
+      if (trimmed.startsWith("!")) continue;
+      /** Skip glob patterns — different transform and risk of false positives */
+      if (/[*?[\]]/.test(trimmed)) continue;
 
       let pattern = trimmed;
+      if (pattern.endsWith("/")) {
+        pattern = pattern.slice(0, -1);
+      }
       if (pattern.startsWith("/")) {
         pattern = pattern.substring(1);
       } else {
         pattern = `**/${pattern}`;
       }
-      if (!pattern.endsWith("/**")) {
-        pattern = `${pattern}/**`;
-      }
-      patterns.push(pattern);
+      patterns.push(`${pattern}/**`);
     }
 
     return patterns;
@@ -76,9 +88,10 @@ function parseGitignoreDirsFallback(repoRoot: string): string[] {
  * Find `.env` and `.env.*` files Envi should capture.
  *
  * In a git repository, only files that git considers ignored are returned.
- * Tracked files (including those added with `git add -f`) are placed in
- * `skippedTracked` so the caller can surface them. Outside a git repository,
- * all matched files are returned.
+ * Files that are tracked or otherwise not covered by an ignore rule are placed
+ * in `excluded` so the caller can surface them. Outside a git repository — or
+ * if `git check-ignore` fails (e.g. git binary missing) — all matched files are
+ * returned and `excluded` is empty.
  *
  * @param repoRoot - Absolute path to repository root
  */
@@ -100,12 +113,21 @@ export async function findEnvFiles(
   });
 
   if (!inGitRepo) {
-    return { files: candidates, skippedTracked: [] };
+    return { files: candidates, excluded: [] };
   }
 
-  const ignored = await filterGitIgnoredFiles(repoRoot, candidates);
-  const ignoredSet = new Set(ignored);
-  const skippedTracked = candidates.filter((path) => !ignoredSet.has(path));
+  let ignored: string[];
+  try {
+    ignored = await filterGitIgnoredFiles(repoRoot, candidates);
+  } catch (error) {
+    consola.warn(
+      `Could not check gitignore status (${getErrorMessage(error)}). Capturing all matched .env files.`,
+    );
+    return { files: candidates, excluded: [] };
+  }
 
-  return { files: ignored, skippedTracked };
+  const ignoredSet = new Set(ignored);
+  const excluded = candidates.filter((path) => !ignoredSet.has(path));
+
+  return { files: ignored, excluded };
 }

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,5 +1,6 @@
 /** Barrel file for utils */
 export { findEnvFiles } from "./find-env-files";
+export type { FindEnvFilesResult } from "./find-env-files";
 export { findRepoRoot } from "./find-repo-root";
 export { getErrorMessage } from "./get-error-message";
 export { parseEnvFile } from "./parse-env-file";


### PR DESCRIPTION
Previously `findEnvFiles` returned every `.env` / `.env.*` it could glob, including ones checked into version control. Capturing those into the Envi store meant a later `restore` could overwrite the committed copy with stale data — and silently, since the user had no way to know a tracked file had been picked up.

In a git repository, `findEnvFiles` now filters candidates through `git check-ignore`, so only files git considers ignored are captured. Tracked files (including those force-added with `git add -f`) are surfaced to the user as skipped so the exclusion is visible. Going through `git check-ignore` instead of parsing `.gitignore` ourselves means nested `.gitignore` files, repo-local `.git/info/exclude`, the user's global ignore, and negation rules are all honored — important in monorepos where a subpackage may track a `.env` that the root ignores, or vice versa.

Outside a git repository, behavior is unchanged: all matched files are returned, with a best-effort parse of the root `.gitignore` for directory patterns so the glob does not descend into ignored build outputs.

Scope: `cli`
Visibility: user-facing