### PR TITLE
Apply prettier formatting

### DIFF
--- a/src/commands/unpack.ts
+++ b/src/commands/unpack.ts
@@ -129,9 +129,10 @@ export async function unpackCommand(blob?: string): Promise<void> {
 
     /**
      * Decryption key resolution order:
-     *   1. encryption_key from envi.maml (preferred — stable across dep updates)
-     *   2. Each configured manifest file (legacy / convenience)
-     *   3. Prompt for a custom secret
+     *
+     * 1. Encryption_key from envi.maml (preferred — stable across dep updates)
+     * 2. Each configured manifest file (legacy / convenience)
+     * 3. Prompt for a custom secret
      */
     let decrypted: string | null = null;
     let secret: string;
@@ -140,7 +141,9 @@ export async function unpackCommand(blob?: string): Promise<void> {
 
     const keyFromConfig = readEncryptionKey(repoRoot);
     if (keyFromConfig) {
-      consola.info(`Found encryption_key in ${KEY_FILE_NAME} - attempting decryption`);
+      consola.info(
+        `Found encryption_key in ${KEY_FILE_NAME} - attempting decryption`,
+      );
       try {
         consola.start("Decrypting configuration...");
         decrypted = decrypt(encryptedData, keyFromConfig);

--- a/src/lib/key-file.ts
+++ b/src/lib/key-file.ts
@@ -24,9 +24,7 @@ const COMMENT_BLOCK = [
   "# env values.",
 ];
 
-/**
- * Get the absolute path to envi.maml in a repository
- */
+/** Get the absolute path to envi.maml in a repository */
 export function getKeyFilePath(repoRoot: string): string {
   return join(repoRoot, KEY_FILE_NAME);
 }
@@ -75,13 +73,13 @@ export interface WriteEncryptionKeyOptions {
 /**
  * Write the encryption key to envi.maml.
  *
- * - If envi.maml does not exist, creates it with a header comment explaining
- *   what the file is for.
+ * - If envi.maml does not exist, creates it with a header comment explaining what
+ *   the file is for.
  * - If envi.maml exists and already has an `encryption_key`, refuses unless
  *   `force` is set, in which case the existing value is replaced in place
  *   (preserves surrounding content and comments).
- * - If envi.maml exists without an `encryption_key`, appends the field
- *   inside the top-level object, preserving the rest of the file.
+ * - If envi.maml exists without an `encryption_key`, appends the field inside the
+ *   top-level object, preserving the rest of the file.
  *
  * @throws Error when `force` is false and a key is already set.
  */
@@ -106,10 +104,7 @@ export function writeEncryptionKey(
   }
 
   const content = readFileSync(path, "utf-8");
-  const keyLine = new RegExp(
-    `^(\\s*)${ENCRYPTION_KEY_FIELD}:\\s*"[^"]*"`,
-    "m",
-  );
+  const keyLine = new RegExp(`^(\\s*)${ENCRYPTION_KEY_FIELD}:\\s*"[^"]*"`, "m");
 
   if (keyLine.test(content)) {
     if (!force) {
@@ -146,9 +141,9 @@ export function writeEncryptionKey(
 /**
  * Generate a new encryption key
  *
- * Returns 32 cryptographically random bytes encoded as base64url (~43 chars,
- * no padding). The key is opaque and used directly as the secret for
- * `encrypt()` / `decrypt()` in src/utils/encryption.ts.
+ * Returns 32 cryptographically random bytes encoded as base64url (~43 chars, no
+ * padding). The key is opaque and used directly as the secret for `encrypt()` /
+ * `decrypt()` in src/utils/encryption.ts.
  */
 export function generateKey(): string {
   return randomBytes(32).toString("base64url");

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -143,8 +143,8 @@ function isContentIdentical(
     /**
      * Force a rewrite when the on-disk format doesn't match the format we'd
      * write now. Without this, running `envi create-key` followed by `envi
-     * capture` would silently leave the store as plaintext when values
-     * happen to be unchanged, which would be a serious foot-gun.
+     * capture` would silently leave the store as plaintext when values happen
+     * to be unchanged, which would be a serious foot-gun.
      */
     const willWriteEncrypted = encryptionKey !== null;
     const existingHasEncrypted = existingData.files.some(isEncryptedEntry);
@@ -211,7 +211,10 @@ export function saveToStorage(
   const filename = getStorageFilename(repoPath, packageName);
   const filePath = join(storageDir, filename);
 
-  /** Check if content is identical to existing file (compares in plaintext space) */
+  /**
+   * Check if content is identical to existing file (compares in plaintext
+   * space)
+   */
   if (isContentIdentical(filePath, sortedFiles, encryptionKey)) {
     return false;
   }


### PR DESCRIPTION
The `Quality Checks` workflow has been failing on main since #3 was merged because three files were committed without prettier formatting:

- `src/commands/unpack.ts`
- `src/lib/key-file.ts`
- `src/lib/storage.ts`

Ran `prettier --write` on the affected files. Changes are purely cosmetic (line wrapping and JSDoc style); no logic was touched. All other checks (lint, type-check, tests) were already green.

Scope: `tooling`
Visibility: `internal`