### PR TITLE
Add npm publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,157 @@
+name: Publish
+
+on:
+  workflow_dispatch:
+    inputs:
+      bump:
+        description: "Version bump type"
+        required: true
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+          - prepatch
+          - preminor
+          - premajor
+          - prerelease
+      preid:
+        description: "Prerelease identifier (alpha, beta, rc). Only used with pre* bumps."
+        required: false
+        type: string
+      explicit_version:
+        description: "Explicit version (e.g. 2.0.0-beta.1). Overrides bump and preid when set."
+        required: false
+        type: string
+      dry_run:
+        description: "Dry run — skip publish, push, and release"
+        required: false
+        type: boolean
+        default: false
+
+concurrency:
+  group: publish
+  cancel-in-progress: false
+
+jobs:
+  checks:
+    if: github.ref == 'refs/heads/main' || startsWith(inputs.bump, 'pre') || inputs.explicit_version != ''
+    uses: ./.github/workflows/checks.yml
+
+  publish:
+    if: github.ref == 'refs/heads/main' || startsWith(inputs.bump, 'pre') || inputs.explicit_version != ''
+    needs: checks
+    runs-on: ubuntu-latest
+    # Authentication is handled via OIDC trusted publishing (id-token),
+    # so no NPM_TOKEN secret is needed.
+    permissions:
+      contents: write
+      id-token: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Enable corepack
+        run: corepack enable pnpm
+
+      - name: Get pnpm store directory
+        id: pnpm-cache
+        shell: bash
+        run: |
+          echo "STORE_PATH=$(pnpm store path)" >> $GITHUB_OUTPUT
+
+      - name: Setup pnpm cache
+        uses: actions/cache@v4
+        with:
+          path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-store-
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build
+        run: pnpm build
+
+      - name: Configure git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Bump version
+        id: version
+        env:
+          BUMP: ${{ inputs.bump }}
+          PREID: ${{ inputs.preid }}
+          EXPLICIT_VERSION: ${{ inputs.explicit_version }}
+        run: |
+          if [[ -n "$EXPLICIT_VERSION" ]]; then
+            npm version "$EXPLICIT_VERSION" --git-tag-version true
+          else
+            ARGS=("$BUMP")
+            if [[ "$BUMP" == pre* && -n "$PREID" ]]; then
+              ARGS+=(--preid "$PREID")
+            fi
+            npm version "${ARGS[@]}" --git-tag-version true
+          fi
+
+          VERSION=$(node -p "require('./package.json').version")
+          TAG="v${VERSION}"
+
+          echo "version=${VERSION}" >> $GITHUB_OUTPUT
+          echo "tag=${TAG}" >> $GITHUB_OUTPUT
+
+          if [[ "$VERSION" == *-* ]]; then
+            echo "dist_tag=next" >> $GITHUB_OUTPUT
+            echo "prerelease=true" >> $GITHUB_OUTPUT
+          else
+            echo "dist_tag=latest" >> $GITHUB_OUTPUT
+            echo "prerelease=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Publish summary
+        run: |
+          echo "### Publish Summary" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "- **Version:** ${{ steps.version.outputs.version }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **Tag:** ${{ steps.version.outputs.tag }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **Dist tag:** ${{ steps.version.outputs.dist_tag }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **Prerelease:** ${{ steps.version.outputs.prerelease }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **Dry run:** ${{ inputs.dry_run }}" >> $GITHUB_STEP_SUMMARY
+
+      # Publish before push: npm publish is not retryable (same version
+      # can't be published twice), while git push is idempotent. If push
+      # fails after a successful publish, it can simply be retried manually.
+      - name: Publish to npm
+        if: ${{ inputs.dry_run == false }}
+        run: |
+          npm publish --provenance --tag ${{ steps.version.outputs.dist_tag }}
+
+      - name: Push version commit
+        if: ${{ inputs.dry_run == false }}
+        run: git push origin HEAD
+
+      - name: Push version tag
+        if: ${{ inputs.dry_run == false }}
+        run: git push origin ${{ steps.version.outputs.tag }}
+
+      - name: Create GitHub Release
+        if: ${{ inputs.dry_run == false }}
+        run: |
+          PRERELEASE_FLAG=""
+          if [[ "${{ steps.version.outputs.prerelease }}" == "true" ]]; then
+            PRERELEASE_FLAG="--prerelease"
+          fi
+
+          gh release create "${{ steps.version.outputs.tag }}" \
+            --generate-notes \
+            $PRERELEASE_FLAG
+        env:
+          GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -75,6 +75,10 @@ jobs:
             ${{ runner.os }}-pnpm-store-
 
       - name: Install dependencies
+        # LEFTHOOK=0 short-circuits `lefthook install` (the `prepare` script);
+        # the runner has no use for git hooks.
+        env:
+          LEFTHOOK: 0
         run: pnpm install --frozen-lockfile
 
       - name: Build
@@ -93,6 +97,12 @@ jobs:
           EXPLICIT_VERSION: ${{ inputs.explicit_version }}
         run: |
           if [[ -n "$EXPLICIT_VERSION" ]]; then
+            # Fail fast on typos rather than letting `npm version` surface
+            # a less obvious error.
+            if [[ ! "$EXPLICIT_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]]; then
+              echo "::error::explicit_version must be a valid semver (e.g. 2.0.0 or 2.0.0-beta.1), got: $EXPLICIT_VERSION"
+              exit 1
+            fi
             npm version "$EXPLICIT_VERSION" --git-tag-version true
           else
             ARGS=("$BUMP")

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -149,20 +149,20 @@ jobs:
       # `pnpm build`); the explicit Build step above already produced the
       # artifact.
       - name: Publish to npm
-        if: ${{ inputs.dry_run != 'true' }}
+        if: ${{ !fromJSON(inputs.dry_run) }}
         run: |
           npm publish --provenance --ignore-scripts --tag ${{ steps.version.outputs.dist_tag }}
 
       - name: Push version commit
-        if: ${{ inputs.dry_run != 'true' }}
+        if: ${{ !fromJSON(inputs.dry_run) }}
         run: git push origin HEAD:${{ github.ref_name }}
 
       - name: Push version tag
-        if: ${{ inputs.dry_run != 'true' }}
+        if: ${{ !fromJSON(inputs.dry_run) }}
         run: git push origin ${{ steps.version.outputs.tag }}
 
       - name: Create GitHub Release
-        if: ${{ inputs.dry_run != 'true' }}
+        if: ${{ !fromJSON(inputs.dry_run) }}
         run: |
           PRERELEASE_FLAG=""
           if [[ "${{ steps.version.outputs.prerelease }}" == "true" ]]; then

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -51,11 +51,15 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # `registry-url` is intentionally omitted: when set, setup-node writes
+      # an `.npmrc` with `_authToken=${NODE_AUTH_TOKEN}` and may export a
+      # placeholder `NODE_AUTH_TOKEN`, which takes precedence over the OIDC
+      # token exchange used by trusted publishing and surfaces as a 404.
+      # See actions/setup-node#1440. npm defaults to registry.npmjs.org.
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
           node-version: 24
-          registry-url: "https://registry.npmjs.org"
 
       - name: Enable corepack
         run: corepack enable pnpm
@@ -81,14 +85,15 @@ jobs:
           LEFTHOOK: 0
         run: pnpm install --frozen-lockfile
 
-      - name: Build
-        run: pnpm build
-
       - name: Configure git
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
+      # Bump must precede Build: `src/cli.ts` reads the version from
+      # `package.json` and tsdown inlines it, so the artifact needs to be
+      # built against the bumped manifest. `npm publish --ignore-scripts`
+      # below skips `prepublishOnly` to avoid a duplicate build.
       - name: Bump version
         id: version
         env:
@@ -125,6 +130,9 @@ jobs:
             echo "dist_tag=latest" >> $GITHUB_OUTPUT
             echo "prerelease=false" >> $GITHUB_OUTPUT
           fi
+
+      - name: Build
+        run: pnpm build
 
       - name: Publish summary
         run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -35,11 +35,11 @@ concurrency:
 
 jobs:
   checks:
-    if: github.ref == 'refs/heads/main' || startsWith(inputs.bump, 'pre') || inputs.explicit_version != ''
+    if: github.ref_type == 'branch' && (github.ref == 'refs/heads/main' || startsWith(inputs.bump, 'pre') || inputs.explicit_version != '')
     uses: ./.github/workflows/checks.yml
 
   publish:
-    if: github.ref == 'refs/heads/main' || startsWith(inputs.bump, 'pre') || inputs.explicit_version != ''
+    if: github.ref_type == 'branch' && (github.ref == 'refs/heads/main' || startsWith(inputs.bump, 'pre') || inputs.explicit_version != '')
     needs: checks
     runs-on: ubuntu-latest
     # Authentication is handled via OIDC trusted publishing (id-token),
@@ -129,14 +129,18 @@ jobs:
       # Publish before push: npm publish is not retryable (same version
       # can't be published twice), while git push is idempotent. If push
       # fails after a successful publish, it can simply be retried manually.
+      #
+      # `--ignore-scripts` skips `prepublishOnly` (which would re-run
+      # `pnpm build`); the explicit Build step above already produced the
+      # artifact.
       - name: Publish to npm
         if: ${{ inputs.dry_run == false }}
         run: |
-          npm publish --provenance --tag ${{ steps.version.outputs.dist_tag }}
+          npm publish --provenance --ignore-scripts --tag ${{ steps.version.outputs.dist_tag }}
 
       - name: Push version commit
         if: ${{ inputs.dry_run == false }}
-        run: git push origin HEAD
+        run: git push origin HEAD:${{ github.ref_name }}
 
       - name: Push version tag
         if: ${{ inputs.dry_run == false }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -102,12 +102,9 @@ jobs:
           EXPLICIT_VERSION: ${{ inputs.explicit_version }}
         run: |
           if [[ -n "$EXPLICIT_VERSION" ]]; then
-            # Fail fast on typos rather than letting `npm version` surface
-            # a less obvious error.
-            if [[ ! "$EXPLICIT_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]]; then
-              echo "::error::explicit_version must be a valid semver (e.g. 2.0.0 or 2.0.0-beta.1), got: $EXPLICIT_VERSION"
-              exit 1
-            fi
+            # `npm version` itself rejects invalid semver with a clear
+            # error before mutating package.json, so we don't add a
+            # second (looser) regex check here.
             npm version "$EXPLICIT_VERSION" --git-tag-version true
           else
             ARGS=("$BUMP")
@@ -152,20 +149,20 @@ jobs:
       # `pnpm build`); the explicit Build step above already produced the
       # artifact.
       - name: Publish to npm
-        if: ${{ inputs.dry_run == false }}
+        if: ${{ inputs.dry_run != 'true' }}
         run: |
           npm publish --provenance --ignore-scripts --tag ${{ steps.version.outputs.dist_tag }}
 
       - name: Push version commit
-        if: ${{ inputs.dry_run == false }}
+        if: ${{ inputs.dry_run != 'true' }}
         run: git push origin HEAD:${{ github.ref_name }}
 
       - name: Push version tag
-        if: ${{ inputs.dry_run == false }}
+        if: ${{ inputs.dry_run != 'true' }}
         run: git push origin ${{ steps.version.outputs.tag }}
 
       - name: Create GitHub Release
-        if: ${{ inputs.dry_run == false }}
+        if: ${{ inputs.dry_run != 'true' }}
         run: |
           PRERELEASE_FLAG=""
           if [[ "${{ steps.version.outputs.prerelease }}" == "true" ]]; then

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 
 import { defineCommand, runMain } from "citty";
+import pkg from "../package.json" with { type: "json" };
 import { captureCommand } from "~/commands/capture";
 import { clearCommand } from "~/commands/clear";
 import { createKeyCommand } from "~/commands/create-key";
@@ -310,7 +311,7 @@ const global = defineCommand({
 const main = defineCommand({
   meta: {
     name: "envi",
-    version: "1.0.0",
+    version: pkg.version,
     description: "Environment file management tool",
   },
   subCommands: {


### PR DESCRIPTION
Adds a manual npm publish workflow modeled on `0x80/isolate-package`.

**How it works**

- Triggered manually via `workflow_dispatch` with three inputs: a `bump` choice (patch/minor/major/prepatch/preminor/premajor/prerelease), an optional `preid` (alpha/beta/rc), and an optional `explicit_version` that overrides both. A `dry_run` toggle skips publish, push, and release. `npm version` validates `explicit_version` itself, so invalid input fails before mutating anything.
- Reuses `checks.yml` as a gating job — non-prerelease, non-explicit publishes can only run from `main`. Prereleases and explicit versions can be published from any branch. The workflow is restricted to branch refs (`github.ref_type == 'branch'`) so it can't be dispatched from a tag.
- Step order: install → bump → build → publish → push → release. The bump runs before build because `src/cli.ts` reads its version from `package.json` (now imported via `import pkg from "../package.json" with { type: "json" }`); tsdown inlines the value so the published artifact reports the right version.
- Publishes with `npm publish --provenance --ignore-scripts`. `--ignore-scripts` skips `prepublishOnly` (which would re-run `pnpm build`); the explicit Build step above already produced the artifact.
- Only after a successful publish does the workflow push the version commit to the dispatch branch and the tag, then cut a GitHub release with `--generate-notes`. Publish-before-push because `npm publish` isn't retryable while `git push` is.
- Prereleases are published under the `next` dist-tag and marked as GitHub prereleases; stable releases go to `latest`.

**Authentication**

Uses npm's OIDC trusted publishing (`id-token: write` permission). No `NPM_TOKEN` secret needed, but the package needs to be configured for trusted publishing on npmjs.com — under the package's settings, add a trusted publisher pointing at `0x80/envi` with workflow `publish.yml` and environment left blank.

`actions/setup-node` is intentionally configured **without** `registry-url`. When `registry-url` is set, setup-node writes an `.npmrc` with `_authToken=${NODE_AUTH_TOKEN}` and exports a placeholder `NODE_AUTH_TOKEN`, which takes precedence over npm's OIDC token exchange and surfaces as a 404 from `npm publish` (see `actions/setup-node#1440`). Without `registry-url`, npm defaults to the public registry and the OIDC flow proceeds cleanly.

**Branch protection**

If `main` has branch protection rules requiring PR reviews or signed commits, the `Push version commit` step (running as `github-actions[bot]`) will fail. The npm publish has already succeeded by then, so recovery is to push the local bump commit manually. To avoid that, add a bypass for `github-actions` (or this workflow) in the branch protection ruleset before the first run.

**Notes**

- Runs on Node 24, matching the reference. The package itself still targets Node 20 (see `tsdown.config.ts`) and `engines.node >= 20`, so the artifact stays compatible.
- The Install step sets `LEFTHOOK=0` so the `prepare` script (`lefthook install`) is a no-op in CI.
- The `checks.yml` reference is unchanged — it already has a `workflow_call:` trigger.

Scope: `tooling`
Visibility: `internal`