### PR TITLE
Sync package.json to published 1.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codecompose/envi",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Envi makes it easy to capture all env files from a codebase in a central location that can be version controlled, and restored for new checkouts and spawning git worktree instances.",
   "keywords": [
     "ai-development",


### PR DESCRIPTION
## Summary

- Bumps `package.json` from 1.0.0 to 1.1.0 to match what's already on npm
- Cleanup for [run #24998605144](https://github.com/0x80/envi/actions/runs/24998605144/job/73202293322), where the publish workflow successfully published 1.1.0 to npm but its `git push origin HEAD:main` was rejected by the branch protection rule

## Follow-up

- After merge: create the missing `v1.1.0` tag and GitHub release pointing at the merge commit

The branch rule that blocked the original push has since been relaxed to allow direct commits on `main`, so the publish workflow itself does not need changes.