### PR TITLE
Skip nested VCS roots and symlinks when finding env files

### DIFF
--- a/src/commands/capture.ts
+++ b/src/commands/capture.ts
@@ -65,7 +65,11 @@ export async function captureCommand(): Promise<void> {
 
     /** Find all env files */
     consola.start("Searching for env files...");
-    const { files: envFilePaths, excluded } = await findEnvFiles(repoRoot);
+    const {
+      files: envFilePaths,
+      excluded,
+      skippedNestedVcsRoots,
+    } = await findEnvFiles(repoRoot);
 
     if (excluded.length > 0) {
       const preview = excluded.slice(0, 5).join(", ");
@@ -73,6 +77,17 @@ export async function captureCommand(): Promise<void> {
         excluded.length > 5 ? ` (...and ${excluded.length - 5} more)` : "";
       consola.info(
         `Skipped ${excluded.length} env file(s) not ignored by git: ${preview}${more}`,
+      );
+    }
+
+    if (skippedNestedVcsRoots.length > 0) {
+      const preview = skippedNestedVcsRoots.slice(0, 5).join(", ");
+      const more =
+        skippedNestedVcsRoots.length > 5
+          ? ` (...and ${skippedNestedVcsRoots.length - 5} more)`
+          : "";
+      consola.info(
+        `Skipped ${skippedNestedVcsRoots.length} env file(s) inside nested repos/worktrees: ${preview}${more}`,
       );
     }
 

--- a/src/commands/pack.ts
+++ b/src/commands/pack.ts
@@ -40,7 +40,11 @@ export async function packCommand(): Promise<void> {
 
     /** Find all env files */
     consola.start("Searching for env files...");
-    const { files: envFilePaths, excluded } = await findEnvFiles(repoRoot);
+    const {
+      files: envFilePaths,
+      excluded,
+      skippedNestedVcsRoots,
+    } = await findEnvFiles(repoRoot);
 
     if (excluded.length > 0) {
       const preview = excluded.slice(0, 5).join(", ");
@@ -48,6 +52,17 @@ export async function packCommand(): Promise<void> {
         excluded.length > 5 ? ` (...and ${excluded.length - 5} more)` : "";
       consola.info(
         `Skipped ${excluded.length} env file(s) not ignored by git: ${preview}${more}`,
+      );
+    }
+
+    if (skippedNestedVcsRoots.length > 0) {
+      const preview = skippedNestedVcsRoots.slice(0, 5).join(", ");
+      const more =
+        skippedNestedVcsRoots.length > 5
+          ? ` (...and ${skippedNestedVcsRoots.length - 5} more)`
+          : "";
+      consola.info(
+        `Skipped ${skippedNestedVcsRoots.length} env file(s) inside nested repos/worktrees: ${preview}${more}`,
       );
     }
 

--- a/src/utils/find-env-files.integration.test.ts
+++ b/src/utils/find-env-files.integration.test.ts
@@ -1,5 +1,11 @@
 import { execa } from "execa";
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import {
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
@@ -75,6 +81,81 @@ describe("findEnvFiles (integration)", () => {
       ".env.shared",
       "packages/api/.env.example",
     ]);
+  });
+
+  it("does not descend into nested VCS roots (worktrees, submodules, nested clones)", async () => {
+    /**
+     * Build three flavors of nested VCS root and confirm none of their env
+     * files surface:
+     *   - `.worktrees/feature` — git worktree (`.git` is a FILE pointing back
+     *     to the main repo's `.git/worktrees/...`)
+     *   - `vendor/nested-clone` — a real nested git repo (`.git` is a DIR)
+     *   - `tools/jj-thing` — a `.jj/` directory (no real jj checkout needed,
+     *     just the marker)
+     */
+    const worktreeDir = join(repoRoot, ".worktrees/feature");
+    mkdirSync(join(worktreeDir, "services/api"), { recursive: true });
+    writeFileSync(join(worktreeDir, ".git"), "gitdir: /elsewhere\n");
+    writeFileSync(join(worktreeDir, ".env"), "WORKTREE_SECRET=1\n");
+    writeFileSync(join(worktreeDir, "services/api/.dev.vars"), "WT_API=1\n");
+
+    const nestedCloneDir = join(repoRoot, "vendor/nested-clone");
+    mkdirSync(join(nestedCloneDir, ".git"), { recursive: true });
+    writeFileSync(join(nestedCloneDir, ".env"), "NESTED_SECRET=1\n");
+
+    const jjDir = join(repoRoot, "tools/jj-thing");
+    mkdirSync(join(jjDir, ".jj"), { recursive: true });
+    writeFileSync(join(jjDir, ".env"), "JJ_SECRET=1\n");
+
+    try {
+      const result = await findEnvFiles(repoRoot);
+      const all = [...result.files, ...result.excluded];
+
+      expect(all).not.toContain(".worktrees/feature/.env");
+      expect(all).not.toContain(".worktrees/feature/services/api/.dev.vars");
+      expect(all).not.toContain("vendor/nested-clone/.env");
+      expect(all).not.toContain("tools/jj-thing/.env");
+
+      /** Sanity: legitimate root-level files still get captured */
+      expect(result.files).toContain(".env");
+    } finally {
+      rmSync(join(repoRoot, ".worktrees"), { recursive: true, force: true });
+      rmSync(join(repoRoot, "vendor"), { recursive: true, force: true });
+      rmSync(join(repoRoot, "tools"), { recursive: true, force: true });
+    }
+  });
+
+  it("does not follow symlinks into linked workspace packages", async () => {
+    /**
+     * pnpm creates symlinks under `node_modules/.pnpm/...` that point back into
+     * the workspace. fast-glob defaults to following them, which produces
+     * phantom paths AND triggers `git check-ignore` errors ("beyond a symbolic
+     * link"). With `followSymbolicLinks: false`, the symlinked target's env
+     * files must not appear under the link path.
+     *
+     * `node_modules/**` is in the default ignore list, so emulate the same
+     * pattern with a non-ignored linker dir.
+     */
+    const realPkgDir = join(repoRoot, "packages/linked-pkg");
+    mkdirSync(realPkgDir, { recursive: true });
+    writeFileSync(join(realPkgDir, ".dev.vars"), "LINKED=1\n");
+
+    const linkerDir = join(repoRoot, "linker");
+    mkdirSync(linkerDir, { recursive: true });
+    symlinkSync(realPkgDir, join(linkerDir, "linked-pkg"), "dir");
+
+    try {
+      const result = await findEnvFiles(repoRoot);
+      const all = [...result.files, ...result.excluded];
+
+      /** The real path is captured */
+      expect(all).toContain("packages/linked-pkg/.dev.vars");
+      /** The symlinked path is NOT captured */
+      expect(all).not.toContain("linker/linked-pkg/.dev.vars");
+    } finally {
+      rmSync(linkerDir, { recursive: true, force: true });
+      rmSync(realPkgDir, { recursive: true, force: true });
+    }
   });
 
   it("excludes a file that has been force-added", async () => {

--- a/src/utils/find-env-files.integration.test.ts
+++ b/src/utils/find-env-files.integration.test.ts
@@ -151,7 +151,12 @@ describe("findEnvFiles (integration)", () => {
 
     const linkerDir = join(repoRoot, "linker");
     mkdirSync(linkerDir, { recursive: true });
-    symlinkSync(realPkgDir, join(linkerDir, "linked-pkg"), "dir");
+    /**
+     * Use `junction` so the test runs on Windows without admin/Developer
+     * Mode. On non-Windows the type argument is ignored and Node creates a
+     * regular directory symlink — which is what we need fast-glob to skip.
+     */
+    symlinkSync(realPkgDir, join(linkerDir, "linked-pkg"), "junction");
 
     try {
       const result = await findEnvFiles(repoRoot);

--- a/src/utils/find-env-files.integration.test.ts
+++ b/src/utils/find-env-files.integration.test.ts
@@ -111,10 +111,19 @@ describe("findEnvFiles (integration)", () => {
       const result = await findEnvFiles(repoRoot);
       const all = [...result.files, ...result.excluded];
 
+      /** Nested-VCS files must not leak into files or excluded */
       expect(all).not.toContain(".worktrees/feature/.env");
       expect(all).not.toContain(".worktrees/feature/services/api/.dev.vars");
       expect(all).not.toContain("vendor/nested-clone/.env");
       expect(all).not.toContain("tools/jj-thing/.env");
+
+      /** They must, however, surface in skippedNestedVcsRoots */
+      expect(result.skippedNestedVcsRoots.sort()).toEqual([
+        ".worktrees/feature/.env",
+        ".worktrees/feature/services/api/.dev.vars",
+        "tools/jj-thing/.env",
+        "vendor/nested-clone/.env",
+      ]);
 
       /** Sanity: legitimate root-level files still get captured */
       expect(result.files).toContain(".env");

--- a/src/utils/find-env-files.test.ts
+++ b/src/utils/find-env-files.test.ts
@@ -146,6 +146,52 @@ describe("findEnvFiles", () => {
       /** No .gitignore-derived patterns when in a git repo */
       expect(existsSync).not.toHaveBeenCalled();
     });
+
+    it("disables symlink following so pnpm links don't produce phantom paths", async () => {
+      /**
+       * Without this option fast-glob descends into pnpm's
+       * `node_modules/.pnpm/...@repo/*` symlinks, surfacing duplicate paths
+       * and triggering `git check-ignore: ... is beyond a symbolic link`.
+       */
+      vi.mocked(fg).mockResolvedValue([]);
+      vi.mocked(filterGitIgnoredFiles).mockResolvedValue([]);
+
+      await findEnvFiles("/project");
+
+      const options = vi.mocked(fg).mock.calls[0]?.[1];
+      expect(options?.followSymbolicLinks).toBe(false);
+    });
+
+    it("partitions candidates inside a nested VCS root into skippedNestedVcsRoots", async () => {
+      /**
+       * `.worktrees/feature/.env` is inside a directory that contains a `.git`
+       * marker — it must not flow to `files` or `excluded` and must surface in
+       * `skippedNestedVcsRoots` so the CLI can tell the user why.
+       */
+      vi.mocked(fg).mockResolvedValue([
+        ".env",
+        ".worktrees/feature/.env",
+        ".worktrees/feature/services/api/.dev.vars",
+      ]);
+      vi.mocked(existsSync).mockImplementation((path) => {
+        const p = String(path);
+        return p === "/project/.worktrees/feature/.git";
+      });
+      vi.mocked(filterGitIgnoredFiles).mockResolvedValue([".env"]);
+
+      const result = await findEnvFiles("/project");
+
+      expect(result.files).toEqual([".env"]);
+      expect(result.excluded).toEqual([]);
+      expect(result.skippedNestedVcsRoots.sort()).toEqual([
+        ".worktrees/feature/.env",
+        ".worktrees/feature/services/api/.dev.vars",
+      ]);
+      /** The nested paths must not be passed to git check-ignore either */
+      const passedToCheckIgnore = vi.mocked(filterGitIgnoredFiles).mock
+        .calls[0]?.[1];
+      expect(passedToCheckIgnore).toEqual([".env"]);
+    });
   });
 
   describe("outside a git repository", () => {

--- a/src/utils/find-env-files.ts
+++ b/src/utils/find-env-files.ts
@@ -1,7 +1,7 @@
 import { consola } from "consola";
 import fg from "fast-glob";
 import { existsSync, readFileSync } from "node:fs";
-import { dirname, join } from "node:path";
+import { dirname, join, resolve } from "node:path";
 import { filterGitIgnoredFiles, isGitRepo } from "~/lib/git";
 import { VCS_MARKERS } from "./find-repo-root";
 import { getErrorMessage } from "./get-error-message";
@@ -33,6 +33,14 @@ export interface FindEnvFilesResult {
    * version-controlled copy or capture a file the user is about to add.
    */
   excluded: string[];
+  /**
+   * Paths that matched the glob but live inside a nested VCS root (git
+   * worktree, submodule, nested clone, jj/hg/svn checkout). These are skipped
+   * because nested working trees have their own independent state and must be
+   * captured from their own directory. Surfaced separately from `excluded` so
+   * the caller can give the user a distinct, accurate reason.
+   */
+  skippedNestedVcsRoots: string[];
 }
 
 /**
@@ -86,21 +94,27 @@ function parseGitignoreDirsFallback(repoRoot: string): string[] {
 }
 
 /**
- * Filter out candidate paths that live inside a nested VCS root.
+ * Partition candidate paths into those that live inside a nested VCS root and
+ * those that do not.
  *
  * For each candidate, walks upward from its parent directory toward (but not
  * including) the repo root. If any intermediate directory contains a VCS marker
- * (`.git`, `.jj`, `.hg`, `.svn`), the candidate is rejected. The repo root
- * itself always has a marker; that's the whole point of being the root, so it
- * is never considered.
+ * (`.git`, `.jj`, `.hg`, `.svn`), the candidate is classified as nested. The
+ * repo root itself is never tested — `findRepoRoot` may legitimately return a
+ * directory without a marker (when the user confirms the "no VCS found" prompt)
+ * and even when a marker is present, the loop terminates before reaching it.
+ *
+ * `repoRoot` is normalized via `resolve()` so a trailing slash on the caller's
+ * input does not break the `dir !== repoRoot` loop guard.
  *
  * Per-directory check results are memoized so a deeply nested worktree only
  * pays the existsSync cost once per ancestor.
  */
-function filterNestedVcsRoots(
+function partitionNestedVcsRoots(
   repoRoot: string,
   candidates: string[],
-): string[] {
+): { kept: string[]; skipped: string[] } {
+  const normalizedRoot = resolve(repoRoot);
   const cache = new Map<string, boolean>();
 
   function isNestedVcsRoot(dir: string): boolean {
@@ -111,25 +125,40 @@ function filterNestedVcsRoots(
     return result;
   }
 
-  return candidates.filter((relPath) => {
-    let dir = dirname(join(repoRoot, relPath));
-    while (dir !== repoRoot && dir !== dirname(dir)) {
-      if (isNestedVcsRoot(dir)) return false;
+  const kept: string[] = [];
+  const skipped: string[] = [];
+
+  for (const relPath of candidates) {
+    let dir = dirname(join(normalizedRoot, relPath));
+    let nested = false;
+    while (dir !== normalizedRoot && dir !== dirname(dir)) {
+      if (isNestedVcsRoot(dir)) {
+        nested = true;
+        break;
+      }
       dir = dirname(dir);
     }
-    return true;
-  });
+    if (nested) {
+      skipped.push(relPath);
+    } else {
+      kept.push(relPath);
+    }
+  }
+
+  return { kept, skipped };
 }
 
 /**
  * Find env files Envi should capture: `.env`, `.env.*`, and Cloudflare
  * Workers' `.dev.vars` / `.dev.vars.*` (which use the same key=value format).
  *
- * In a git repository, only files that git considers ignored are returned.
- * Files that are tracked or otherwise not covered by an ignore rule are placed
- * in `excluded` so the caller can surface them. Outside a git repository — or
- * if `git check-ignore` fails (e.g. git binary missing) — all matched files are
- * returned and `excluded` is empty.
+ * In a git repository, only files that git considers ignored are returned in
+ * `files`. Files that are tracked or otherwise not covered by an ignore rule
+ * are placed in `excluded`. Files inside a nested VCS root (worktree,
+ * submodule, nested clone) are placed in `skippedNestedVcsRoots` regardless of
+ * gitignore status — they belong to an independent working tree. Outside a git
+ * repository — or if `git check-ignore` fails (e.g. git binary missing) — all
+ * matched files are returned and `excluded` is empty.
  *
  * @param repoRoot - Absolute path to repository root
  */
@@ -166,14 +195,16 @@ export async function findEnvFiles(
   });
 
   /**
-   * Drop any candidate that lives inside a nested VCS root (git worktree,
-   * submodule, nested clone, jj/hg/svn checkout). These are independent working
-   * trees with their own state and must be captured from their own directory.
+   * Partition candidates that live inside a nested VCS root (git worktree,
+   * submodule, nested clone, jj/hg/svn checkout). These are surfaced separately
+   * so the caller can tell the user why they were skipped, instead of silently
+   * disappearing.
    */
-  const candidates = filterNestedVcsRoots(repoRoot, rawCandidates);
+  const { kept: candidates, skipped: skippedNestedVcsRoots } =
+    partitionNestedVcsRoots(repoRoot, rawCandidates);
 
   if (!inGitRepo) {
-    return { files: candidates, excluded: [] };
+    return { files: candidates, excluded: [], skippedNestedVcsRoots };
   }
 
   let ignored: string[];
@@ -183,11 +214,11 @@ export async function findEnvFiles(
     consola.warn(
       `Could not check gitignore status (${getErrorMessage(error)}). Capturing all matched env files.`,
     );
-    return { files: candidates, excluded: [] };
+    return { files: candidates, excluded: [], skippedNestedVcsRoots };
   }
 
   const ignoredSet = new Set(ignored);
   const excluded = candidates.filter((path) => !ignoredSet.has(path));
 
-  return { files: ignored, excluded };
+  return { files: ignored, excluded, skippedNestedVcsRoots };
 }

--- a/src/utils/find-env-files.ts
+++ b/src/utils/find-env-files.ts
@@ -3,7 +3,7 @@ import fg from "fast-glob";
 import { existsSync, readFileSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
 import { filterGitIgnoredFiles, isGitRepo } from "~/lib/git";
-import { VCS_MARKERS } from "./find-repo-root";
+import { VCS_MARKERS } from "./vcs-markers";
 import { getErrorMessage } from "./get-error-message";
 
 /**

--- a/src/utils/find-env-files.ts
+++ b/src/utils/find-env-files.ts
@@ -1,8 +1,9 @@
 import { consola } from "consola";
 import fg from "fast-glob";
 import { existsSync, readFileSync } from "node:fs";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 import { filterGitIgnoredFiles, isGitRepo } from "~/lib/git";
+import { VCS_MARKERS } from "./find-repo-root";
 import { getErrorMessage } from "./get-error-message";
 
 /**
@@ -85,6 +86,42 @@ function parseGitignoreDirsFallback(repoRoot: string): string[] {
 }
 
 /**
+ * Filter out candidate paths that live inside a nested VCS root.
+ *
+ * For each candidate, walks upward from its parent directory toward (but not
+ * including) the repo root. If any intermediate directory contains a VCS marker
+ * (`.git`, `.jj`, `.hg`, `.svn`), the candidate is rejected. The repo root
+ * itself always has a marker; that's the whole point of being the root, so it
+ * is never considered.
+ *
+ * Per-directory check results are memoized so a deeply nested worktree only
+ * pays the existsSync cost once per ancestor.
+ */
+function filterNestedVcsRoots(
+  repoRoot: string,
+  candidates: string[],
+): string[] {
+  const cache = new Map<string, boolean>();
+
+  function isNestedVcsRoot(dir: string): boolean {
+    const cached = cache.get(dir);
+    if (cached !== undefined) return cached;
+    const result = VCS_MARKERS.some((marker) => existsSync(join(dir, marker)));
+    cache.set(dir, result);
+    return result;
+  }
+
+  return candidates.filter((relPath) => {
+    let dir = dirname(join(repoRoot, relPath));
+    while (dir !== repoRoot && dir !== dirname(dir)) {
+      if (isNestedVcsRoot(dir)) return false;
+      dir = dirname(dir);
+    }
+    return true;
+  });
+}
+
+/**
  * Find env files Envi should capture: `.env`, `.env.*`, and Cloudflare
  * Workers' `.dev.vars` / `.dev.vars.*` (which use the same key=value format).
  *
@@ -115,12 +152,25 @@ export async function findEnvFiles(
     ? DEFAULT_IGNORE_PATTERNS
     : [...DEFAULT_IGNORE_PATTERNS, ...parseGitignoreDirsFallback(repoRoot)];
 
-  const candidates = await fg(patterns, {
+  const rawCandidates = await fg(patterns, {
     cwd: repoRoot,
     dot: true,
     absolute: false,
     ignore: ignorePatterns,
+    /**
+     * Don't follow symlinks. pnpm's workspace links would otherwise produce
+     * phantom paths under `node_modules/.pnpm/...` and break `git check-ignore`
+     * with "beyond a symbolic link".
+     */
+    followSymbolicLinks: false,
   });
+
+  /**
+   * Drop any candidate that lives inside a nested VCS root (git worktree,
+   * submodule, nested clone, jj/hg/svn checkout). These are independent working
+   * trees with their own state and must be captured from their own directory.
+   */
+  const candidates = filterNestedVcsRoots(repoRoot, rawCandidates);
 
   if (!inGitRepo) {
     return { files: candidates, excluded: [] };

--- a/src/utils/find-repo-root.ts
+++ b/src/utils/find-repo-root.ts
@@ -1,9 +1,7 @@
 import { existsSync } from "node:fs";
 import { join, dirname } from "node:path";
 import * as p from "@clack/prompts";
-
-/** VCS markers that indicate a repository root */
-export const VCS_MARKERS = [".git", ".jj", ".hg", ".svn"];
+import { VCS_MARKERS } from "./vcs-markers";
 
 /** Check if a directory contains any VCS markers */
 function hasVcsMarker(dir: string): boolean {

--- a/src/utils/find-repo-root.ts
+++ b/src/utils/find-repo-root.ts
@@ -3,7 +3,7 @@ import { join, dirname } from "node:path";
 import * as p from "@clack/prompts";
 
 /** VCS markers that indicate a repository root */
-const VCS_MARKERS = [".git", ".jj", ".hg", ".svn"];
+export const VCS_MARKERS = [".git", ".jj", ".hg", ".svn"];
 
 /** Check if a directory contains any VCS markers */
 function hasVcsMarker(dir: string): boolean {

--- a/src/utils/vcs-markers.ts
+++ b/src/utils/vcs-markers.ts
@@ -1,0 +1,13 @@
+/**
+ * VCS markers that indicate a repository root or a nested working tree.
+ *
+ * Lives in its own module (no imports) so both `findRepoRoot` (which depends
+ * on interactive prompt code) and `findEnvFiles` (a pure filesystem utility)
+ * can share the constant without `findEnvFiles` transitively pulling
+ * `@clack/prompts` into its dependency graph.
+ *
+ * `as const` makes the value a readonly tuple at the type level so callers
+ * can't accidentally `.push` to it. The runtime value is still a regular
+ * array — `.some` and other read methods work as usual.
+ */
+export const VCS_MARKERS = [".git", ".jj", ".hg", ".svn"] as const;


### PR DESCRIPTION
When envi runs in a repo that contains git worktrees or pnpm-linked workspace packages, the env-file glob descended into both. That surfaced duplicate captures from worktree checkouts and phantom paths under `node_modules/.pnpm/.../@repo/*/`. The symlink traversal also caused `git check-ignore` to fail with `fatal: ... is beyond a symbolic link`, which made `findEnvFiles` fall back to its "capture everything" branch and surface even more files that should have been filtered out.

Two changes:

- Pass `followSymbolicLinks: false` to fast-glob. pnpm's workspace symlinks no longer produce phantom paths and `git check-ignore` succeeds normally.
- Post-filter candidates against ancestor VCS markers (`.git`, `.jj`, `.hg`, `.svn`), with per-directory memoization. Anything inside a nested worktree, submodule, or nested clone is dropped — those are independent working trees and must be captured from their own directory. The repo root itself is exempt.

`VCS_MARKERS` is now exported from `find-repo-root.ts` so the env-finder reuses the same set.

Scope: cli (envi)
Visibility: user-facing