### PR TITLE
Integrate remote changes before pushing the envi store

### DIFF
--- a/src/lib/git.test.ts
+++ b/src/lib/git.test.ts
@@ -1,10 +1,43 @@
 import { existsSync } from "node:fs";
 import { execa } from "execa";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { filterGitIgnoredFiles, isGitRepo } from "./git";
+import { commitAndPush, filterGitIgnoredFiles, isGitRepo } from "./git";
 
 vi.mock("node:fs");
 vi.mock("execa");
+
+/**
+ * Build a mock `execa` that resolves based on the git subcommand, so tests can
+ * drive each step (status, fetch, rebase, push) independently regardless of
+ * call order. Any subcommand without an override resolves to a clean success.
+ *
+ * @param overrides - Map of git subcommand (first arg) to its mocked result
+ */
+function mockGit(
+  overrides: Record<string, { exitCode?: number; stdout?: string }> = {},
+): void {
+  vi.mocked(execa).mockImplementation((_cmd, args) => {
+    const subcommand = Array.isArray(args) ? String(args[0]) : "";
+    const override = overrides[subcommand] ?? {};
+    return Promise.resolve({
+      exitCode: override.exitCode ?? 0,
+      stdout: override.stdout ?? "",
+      stderr: "",
+    }) as never;
+  });
+}
+
+/**
+ * Collect the git subcommands execa was called with, in order.
+ *
+ * @returns The first argument of each `git` invocation (e.g. "fetch", "push")
+ */
+function calledGitSubcommands(): string[] {
+  return vi.mocked(execa).mock.calls.map((call) => {
+    const args = call[1];
+    return Array.isArray(args) ? String(args[0]) : "";
+  });
+}
 
 describe("git", () => {
   beforeEach(() => {
@@ -84,6 +117,78 @@ describe("git", () => {
       await expect(filterGitIgnoredFiles("/project", [".env"])).rejects.toThrow(
         /not a git repository/,
       );
+    });
+  });
+
+  describe("commitAndPush", () => {
+    it("returns early without committing when there are no changes", async () => {
+      mockGit({ status: { stdout: "" } });
+
+      await commitAndPush("/envi", "Update env files");
+
+      const subcommands = calledGitSubcommands();
+      expect(subcommands).toContain("add");
+      expect(subcommands).toContain("status");
+      expect(subcommands).not.toContain("commit");
+      expect(subcommands).not.toContain("push");
+    });
+
+    it("fetches and rebases onto the remote before pushing", async () => {
+      mockGit({ status: { stdout: " M store/app.maml" } });
+
+      await commitAndPush("/envi", "Update env files");
+
+      const subcommands = calledGitSubcommands();
+      expect(subcommands).toEqual([
+        "add",
+        "status",
+        "commit",
+        "fetch",
+        "rebase",
+        "push",
+      ]);
+      expect(execa).toHaveBeenCalledWith(
+        "git",
+        ["fetch", "origin", "main"],
+        expect.objectContaining({ cwd: "/envi", reject: false }),
+      );
+      expect(execa).toHaveBeenCalledWith(
+        "git",
+        ["rebase", "FETCH_HEAD"],
+        expect.objectContaining({ cwd: "/envi", reject: false }),
+      );
+    });
+
+    it("skips the rebase and still pushes when the remote branch does not exist yet", async () => {
+      mockGit({
+        status: { stdout: " M store/app.maml" },
+        fetch: { exitCode: 128 },
+      });
+
+      await commitAndPush("/envi", "Update env files");
+
+      const subcommands = calledGitSubcommands();
+      expect(subcommands).toContain("fetch");
+      expect(subcommands).not.toContain("rebase");
+      expect(subcommands).toContain("push");
+    });
+
+    it("aborts the rebase and throws an actionable error on conflicts", async () => {
+      mockGit({
+        status: { stdout: " M store/app.maml" },
+        rebase: { exitCode: 1 },
+      });
+
+      await expect(commitAndPush("/envi", "Update env files")).rejects.toThrow(
+        /conflicting changes/i,
+      );
+
+      expect(execa).toHaveBeenCalledWith(
+        "git",
+        ["rebase", "--abort"],
+        expect.objectContaining({ cwd: "/envi", reject: false }),
+      );
+      expect(calledGitSubcommands()).not.toContain("push");
     });
   });
 });

--- a/src/lib/git.test.ts
+++ b/src/lib/git.test.ts
@@ -173,14 +173,14 @@ describe("git", () => {
       expect(subcommands).toContain("push");
     });
 
-    it("aborts the rebase and throws an actionable error on conflicts", async () => {
+    it("aborts the rebase and throws an actionable error when the rebase fails", async () => {
       mockGit({
         status: { stdout: " M store/app.maml" },
         rebase: { exitCode: 1 },
       });
 
       await expect(commitAndPush("/envi", "Update env files")).rejects.toThrow(
-        /conflicting changes/i,
+        /could not rebase[\s\S]*git pull --rebase[\s\S]*git push/i,
       );
 
       expect(execa).toHaveBeenCalledWith(
@@ -189,6 +189,35 @@ describe("git", () => {
         expect.objectContaining({ cwd: "/envi", reject: false }),
       );
       expect(calledGitSubcommands()).not.toContain("push");
+    });
+
+    it("includes the rebase stderr in the error for diagnostics", async () => {
+      vi.mocked(execa).mockImplementation((_cmd, args) => {
+        const argv = Array.isArray(args) ? args.map(String) : [];
+        if (argv[0] === "status") {
+          return Promise.resolve({
+            exitCode: 0,
+            stdout: " M store/app.maml",
+            stderr: "",
+          }) as never;
+        }
+        if (argv[0] === "rebase" && argv[1] === "FETCH_HEAD") {
+          return Promise.resolve({
+            exitCode: 1,
+            stdout: "",
+            stderr: "CONFLICT (content): Merge conflict in store/app.maml",
+          }) as never;
+        }
+        return Promise.resolve({
+          exitCode: 0,
+          stdout: "",
+          stderr: "",
+        }) as never;
+      });
+
+      await expect(commitAndPush("/envi", "Update env files")).rejects.toThrow(
+        /Merge conflict in store\/app\.maml/,
+      );
     });
   });
 });

--- a/src/lib/git.ts
+++ b/src/lib/git.ts
@@ -94,9 +94,13 @@ export async function addRemote(dir: string, remoteUrl: string): Promise<void> {
  * Fetches `origin/main` and rebases our local commits on top of it. A failed
  * fetch means the remote branch doesn't exist yet (a fresh repo's first push),
  * in which case there is nothing to integrate and the push will create it. A
- * failed rebase means the remote changed the same store file we did; we abort
- * to leave the working tree clean and surface an actionable error rather than
- * leaving a half-finished rebase behind.
+ * failed rebase usually means the remote changed the same store file we did;
+ * we abort to leave the working tree clean and surface the rebase output so the
+ * user can resolve it, rather than leaving a half-finished rebase behind.
+ *
+ * The local commit already exists at this point, so the recovery is to push it
+ * after rebasing manually — not to capture again (an unchanged working tree
+ * would short-circuit the next capture before it ever reaches a push).
  *
  * @param dir - Repository directory
  */
@@ -117,11 +121,13 @@ async function integrateRemoteChanges(dir: string): Promise<void> {
   });
 
   if (rebaseResult.exitCode !== 0) {
-    /** Restore the working tree before surfacing the conflict */
+    /** Restore the working tree before surfacing the failure */
     await execa("git", ["rebase", "--abort"], { cwd: dir, reject: false });
+    const details = rebaseResult.stderr?.trim();
     throw new Error(
-      `The remote envi-store has conflicting changes that can't be merged automatically. ` +
-        `Resolve them manually in ${dir} (git pull --rebase, fix the conflicts), then capture again.`,
+      `Could not rebase the local envi-store onto the latest origin/main` +
+        (details ? `: ${details}` : "") +
+        `. Resolve it manually in ${dir} (git pull --rebase, fix any conflicts, then git push).`,
     );
   }
 }

--- a/src/lib/git.ts
+++ b/src/lib/git.ts
@@ -88,6 +88,45 @@ export async function addRemote(dir: string, remoteUrl: string): Promise<void> {
 }
 
 /**
+ * Integrate changes the remote has that we don't, so a push isn't rejected
+ * when another machine has pushed to the same store since we last synced.
+ *
+ * Fetches `origin/main` and rebases our local commits on top of it. A failed
+ * fetch means the remote branch doesn't exist yet (a fresh repo's first push),
+ * in which case there is nothing to integrate and the push will create it. A
+ * failed rebase means the remote changed the same store file we did; we abort
+ * to leave the working tree clean and surface an actionable error rather than
+ * leaving a half-finished rebase behind.
+ *
+ * @param dir - Repository directory
+ */
+async function integrateRemoteChanges(dir: string): Promise<void> {
+  const fetchResult = await execa("git", ["fetch", "origin", "main"], {
+    cwd: dir,
+    reject: false,
+  });
+
+  /** No remote `main` yet (or unreachable) — nothing to integrate; let push handle it */
+  if (fetchResult.exitCode !== 0) {
+    return;
+  }
+
+  const rebaseResult = await execa("git", ["rebase", "FETCH_HEAD"], {
+    cwd: dir,
+    reject: false,
+  });
+
+  if (rebaseResult.exitCode !== 0) {
+    /** Restore the working tree before surfacing the conflict */
+    await execa("git", ["rebase", "--abort"], { cwd: dir, reject: false });
+    throw new Error(
+      `The remote envi-store has conflicting changes that can't be merged automatically. ` +
+        `Resolve them manually in ${dir} (git pull --rebase, fix the conflicts), then capture again.`,
+    );
+  }
+}
+
+/**
  * Commit all changes and push to remote
  *
  * @param dir - Repository directory
@@ -115,6 +154,12 @@ export async function commitAndPush(
 
   /** Commit */
   await execa("git", ["commit", "-m", message], { cwd: dir });
+
+  /**
+   * Integrate remote changes before pushing so a remote that is ahead (e.g.
+   * pushed from another machine) doesn't reject our push with "fetch first".
+   */
+  await integrateRemoteChanges(dir);
 
   /** Push to remote */
   await execa("git", ["push", "-u", "origin", "main"], { cwd: dir });


### PR DESCRIPTION
The `~/.envi` store is a git repository shared across machines (each machine clones it via `envi global github restore`). The capture flow committed and pushed without ever fetching, so when another machine had pushed to the shared `envi-store` repo since this machine last synced, the local clone was behind `origin/main` and the push was rejected with `! [rejected] main -> main (fetch first)`.

`commitAndPush` now integrates remote changes before pushing: after committing it fetches `origin/main` and rebases the local commit on top, then pushes. Because each machine captures different repositories into separate store files, this is normally a clean fast-forward. If the fetch fails (no remote `main` yet on a fresh repo, or unreachable) the rebase is skipped and the push proceeds as before. On a genuine conflict (the same store file changed on two machines) the rebase is aborted to leave the working tree clean and an actionable error is surfaced, while the local capture is still saved.

Scope: packages (@codecompose/envi)
Visibility: user-facing
