### PR TITLE
Make env-file discovery resilient to worktrees mid-teardown

### DIFF
--- a/src/commands/capture.ts
+++ b/src/commands/capture.ts
@@ -18,8 +18,9 @@ import {
 import {
   findEnvFiles,
   findRepoRoot,
+  formatSkippedPreview,
   getErrorMessage,
-  parseEnvFile,
+  readEnvFiles,
 } from "~/utils";
 import { applyRedaction } from "~/utils/redact";
 
@@ -81,22 +82,14 @@ export async function captureCommand(): Promise<void> {
     } = await findEnvFiles(repoRoot, { additionalPatterns });
 
     if (excluded.length > 0) {
-      const preview = excluded.slice(0, 5).join(", ");
-      const more =
-        excluded.length > 5 ? ` (...and ${excluded.length - 5} more)` : "";
       consola.info(
-        `Skipped ${excluded.length} env file(s) not ignored by git: ${preview}${more}`,
+        `Skipped ${excluded.length} env file(s) not ignored by git: ${formatSkippedPreview(excluded)}`,
       );
     }
 
     if (skippedNestedVcsRoots.length > 0) {
-      const preview = skippedNestedVcsRoots.slice(0, 5).join(", ");
-      const more =
-        skippedNestedVcsRoots.length > 5
-          ? ` (...and ${skippedNestedVcsRoots.length - 5} more)`
-          : "";
       consola.info(
-        `Skipped ${skippedNestedVcsRoots.length} env file(s) inside nested repos/worktrees: ${preview}${more}`,
+        `Skipped ${skippedNestedVcsRoots.length} env file(s) inside nested repos/worktrees: ${formatSkippedPreview(skippedNestedVcsRoots)}`,
       );
     }
 
@@ -108,16 +101,23 @@ export async function captureCommand(): Promise<void> {
     consola.success(`Found ${envFilePaths.length} file(s):`);
     envFilePaths.forEach((path) => consola.info(`  - ${path}`));
 
-    /** Parse each env file */
+    /** Parse each env file, skipping any that became unreadable since discovery */
     consola.start("Parsing files...");
-    const envFiles = envFilePaths.map((relativePath) => {
-      const absolutePath = join(repoRoot, relativePath);
-      const env = parseEnvFile(absolutePath);
-      return {
-        path: relativePath,
-        env,
-      };
-    });
+    const { parsed: envFiles, unreadable } = readEnvFiles(
+      repoRoot,
+      envFilePaths,
+    );
+
+    if (unreadable.length > 0) {
+      consola.warn(
+        `Skipped ${unreadable.length} unreadable env file(s): ${formatSkippedPreview(unreadable)}`,
+      );
+    }
+
+    if (envFiles.length === 0) {
+      consola.warn("No readable env files found.");
+      return;
+    }
 
     /** Apply redaction to env files */
     const redactedVariables = getRedactedVariables();

--- a/src/commands/capture.ts
+++ b/src/commands/capture.ts
@@ -10,6 +10,7 @@ import {
   getStorageDir,
   getStorageFilename,
   KEY_FILE_NAME,
+  loadStoredPaths,
   readCapturePatterns,
   readConfig,
   readEncryptionKey,
@@ -112,6 +113,26 @@ export async function captureCommand(): Promise<void> {
       consola.warn(
         `Skipped ${unreadable.length} unreadable env file(s): ${formatSkippedPreview(unreadable)}`,
       );
+
+      /**
+       * `saveToStorage` writes a full snapshot, so a file dropped from this
+       * capture is removed from the store. If any unreadable file is already
+       * backed up, overwriting would let a transient read failure (a file
+       * mid-rewrite, a briefly-dangling symlink) shrink the store — refuse
+       * rather than silently lose a previously captured file. Files that were
+       * never stored are safe to skip; nothing is lost.
+       */
+      const storedPaths = loadStoredPaths(repoRoot, packageName);
+      const wouldDrop = unreadable.filter((path) => storedPaths.has(path));
+      if (wouldDrop.length > 0) {
+        consola.error(
+          `Refusing to update the store: ${wouldDrop.length} already-stored file(s) could not be read this run (${formatSkippedPreview(wouldDrop)}).`,
+        );
+        consola.info(
+          "Resolve them and re-run so the store is not overwritten without them.",
+        );
+        return;
+      }
     }
 
     if (envFiles.length === 0) {

--- a/src/commands/pack.ts
+++ b/src/commands/pack.ts
@@ -6,9 +6,10 @@ import clipboard from "clipboardy";
 import { stringify } from "maml.js";
 import {
   findRepoRoot,
+  formatSkippedPreview,
   getErrorMessage,
   findEnvFiles,
-  parseEnvFile,
+  readEnvFiles,
 } from "~/utils";
 import {
   encrypt,
@@ -59,22 +60,14 @@ export async function packCommand(): Promise<void> {
     } = await findEnvFiles(repoRoot, { additionalPatterns });
 
     if (excluded.length > 0) {
-      const preview = excluded.slice(0, 5).join(", ");
-      const more =
-        excluded.length > 5 ? ` (...and ${excluded.length - 5} more)` : "";
       consola.info(
-        `Skipped ${excluded.length} env file(s) not ignored by git: ${preview}${more}`,
+        `Skipped ${excluded.length} env file(s) not ignored by git: ${formatSkippedPreview(excluded)}`,
       );
     }
 
     if (skippedNestedVcsRoots.length > 0) {
-      const preview = skippedNestedVcsRoots.slice(0, 5).join(", ");
-      const more =
-        skippedNestedVcsRoots.length > 5
-          ? ` (...and ${skippedNestedVcsRoots.length - 5} more)`
-          : "";
       consola.info(
-        `Skipped ${skippedNestedVcsRoots.length} env file(s) inside nested repos/worktrees: ${preview}${more}`,
+        `Skipped ${skippedNestedVcsRoots.length} env file(s) inside nested repos/worktrees: ${formatSkippedPreview(skippedNestedVcsRoots)}`,
       );
     }
 
@@ -86,16 +79,23 @@ export async function packCommand(): Promise<void> {
 
     consola.success(`Found ${envFilePaths.length} file(s) to pack`);
 
-    /** Parse each env file */
+    /** Parse each env file, skipping any that became unreadable since discovery */
     consola.start("Reading environment files...");
-    const envFiles = envFilePaths.map((relativePath) => {
-      const absolutePath = join(repoRoot, relativePath);
-      const env = parseEnvFile(absolutePath);
-      return {
-        path: relativePath,
-        env,
-      };
-    });
+    const { parsed: envFiles, unreadable } = readEnvFiles(
+      repoRoot,
+      envFilePaths,
+    );
+
+    if (unreadable.length > 0) {
+      consola.warn(
+        `Skipped ${unreadable.length} unreadable env file(s): ${formatSkippedPreview(unreadable)}`,
+      );
+    }
+
+    if (envFiles.length === 0) {
+      consola.error("No readable env files found in repository.");
+      process.exit(1);
+    }
 
     /** Apply redaction to env files */
     const redactedVariables = getRedactedVariables();

--- a/src/lib/git.test.ts
+++ b/src/lib/git.test.ts
@@ -1,7 +1,12 @@
 import { existsSync } from "node:fs";
 import { execa } from "execa";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { commitAndPush, filterGitIgnoredFiles, isGitRepo } from "./git";
+import {
+  commitAndPush,
+  filterGitIgnoredFiles,
+  isGitRepo,
+  listWorktreePaths,
+} from "./git";
 
 vi.mock("node:fs");
 vi.mock("execa");
@@ -218,6 +223,43 @@ describe("git", () => {
       await expect(commitAndPush("/envi", "Update env files")).rejects.toThrow(
         /Merge conflict in store\/app\.maml/,
       );
+    });
+  });
+
+  describe("listWorktreePaths", () => {
+    it("parses the worktree paths from porcelain -z output", async () => {
+      /**
+       * `--porcelain -z` output: NUL-separated `label value` records, one
+       * stanza per worktree (main tree first), stanzas ending in an empty
+       * record. Only the `worktree <path>` records carry a path.
+       */
+      const stdout = [
+        "worktree /project",
+        "HEAD abc123",
+        "branch refs/heads/main",
+        "",
+        "worktree /project/.worktrees/feature",
+        "HEAD def456",
+        "branch refs/heads/feature",
+        "",
+      ].join("\0");
+      mockGit({ worktree: { stdout } });
+
+      const result = await listWorktreePaths("/project");
+
+      expect(result).toEqual(["/project", "/project/.worktrees/feature"]);
+    });
+
+    it("returns an empty array when git exits non-zero", async () => {
+      mockGit({ worktree: { exitCode: 128 } });
+
+      expect(await listWorktreePaths("/project")).toEqual([]);
+    });
+
+    it("returns an empty array when git is unavailable", async () => {
+      vi.mocked(execa).mockRejectedValue(new Error("spawn git ENOENT"));
+
+      expect(await listWorktreePaths("/project")).toEqual([]);
     });
   });
 });

--- a/src/lib/git.ts
+++ b/src/lib/git.ts
@@ -59,6 +59,57 @@ export async function filterGitIgnoredFiles(
 }
 
 /**
+ * List the absolute paths of every working tree git knows about for this repo —
+ * the main working tree plus every linked worktree created with `git worktree
+ * add`.
+ *
+ * Used as an authoritative complement to the on-disk `.git`-marker probe in
+ * `findEnvFiles`. That probe classifies a directory as a nested working tree by
+ * the presence of a `.git` entry, but a linked worktree momentarily lacks its
+ * `.git` pointer file while git is adding or removing it — and the marker probe
+ * alone would then fail to skip it, capturing another working tree's env files.
+ * `git worktree list` reports the worktree regardless of that transient
+ * on-disk state.
+ *
+ * Best-effort: returns `[]` when git is unavailable, the directory is not a
+ * repository, or the installed git predates `worktree list --porcelain -z`, so
+ * the caller cleanly falls back to marker-only detection. It does not report a
+ * fully orphaned directory whose worktree registration has already been pruned
+ * (git no longer considers that a worktree) — that residual case is covered by
+ * capture/pack tolerating an unreadable file rather than by detection here.
+ *
+ * @param repoRoot - Absolute path to the git repository root
+ * @returns Absolute worktree paths, including the main working tree
+ */
+export async function listWorktreePaths(repoRoot: string): Promise<string[]> {
+  try {
+    const result = await execa(
+      "git",
+      ["worktree", "list", "--porcelain", "-z"],
+      { cwd: repoRoot, reject: false },
+    );
+
+    if (result.exitCode !== 0) {
+      return [];
+    }
+
+    /**
+     * `--porcelain -z` emits NUL-separated `label value` records, one stanza
+     * per worktree. Only the `worktree <path>` record carries the path; the
+     * `HEAD` / `branch` / `bare` records and the empty stanza separators are
+     * ignored.
+     */
+    const prefix = "worktree ";
+    return result.stdout
+      .split("\0")
+      .filter((record) => record.startsWith(prefix))
+      .map((record) => record.slice(prefix.length));
+  } catch {
+    return [];
+  }
+}
+
+/**
  * Initialize a git repository
  *
  * @param dir - Directory to initialize

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -20,6 +20,7 @@ export {
   initialCommitAndPush,
   initGitRepo,
   isGitRepo,
+  listWorktreePaths,
 } from "./git";
 export {
   cloneRepo,

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -53,6 +53,7 @@ export {
   getPackageName,
   getStorageDir,
   getStorageFilename,
+  loadStoredPaths,
   saveToStorage,
 } from "./storage";
 export type { EnviStore, EnviStoreFile } from "./storage";

--- a/src/lib/storage.test.ts
+++ b/src/lib/storage.test.ts
@@ -8,6 +8,7 @@ import {
   getPackageName,
   getStorageDir,
   getStorageFilename,
+  loadStoredPaths,
   saveToStorage,
 } from "./storage";
 
@@ -444,6 +445,45 @@ describe("storage", () => {
         "maml content",
         "utf-8",
       );
+    });
+  });
+
+  describe("loadStoredPaths", () => {
+    beforeEach(() => {
+      vi.mocked(homedir).mockReturnValue("/home/user");
+    });
+
+    it("returns an empty set when no store file exists", () => {
+      vi.mocked(existsSync).mockReturnValue(false);
+
+      expect(loadStoredPaths("/repo", "my-package").size).toBe(0);
+    });
+
+    it("returns every stored path, across plaintext and encrypted entries", () => {
+      vi.mocked(existsSync).mockReturnValue(true);
+      vi.mocked(readFileSync).mockReturnValue("maml content");
+      vi.mocked(parse).mockReturnValue({
+        __envi_version: 1,
+        metadata: { updated_from: "/repo", updated_at: "now" },
+        files: [
+          { path: ".env", env: { A: "1" } },
+          { path: "apps/web/.env.local", encrypted_env: "base64ciphertext" },
+        ],
+      });
+
+      const result = loadStoredPaths("/repo", "my-package");
+
+      expect(result).toEqual(new Set([".env", "apps/web/.env.local"]));
+    });
+
+    it("returns an empty set when the store cannot be parsed", () => {
+      vi.mocked(existsSync).mockReturnValue(true);
+      vi.mocked(readFileSync).mockReturnValue("corrupt");
+      vi.mocked(parse).mockImplementation(() => {
+        throw new Error("bad maml");
+      });
+
+      expect(loadStoredPaths("/repo", "my-package").size).toBe(0);
     });
   });
 });

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -174,6 +174,39 @@ function isContentIdentical(
   }
 }
 
+/**
+ * The set of file paths currently recorded in this repo's store, or an empty
+ * set when no store exists yet.
+ *
+ * Paths are plaintext in both entry variants — only the *values* are ever
+ * encrypted — so this needs no key. `capture` uses it to detect when writing a
+ * fresh snapshot would drop a file that is already backed up but couldn't be
+ * read this run: `saveToStorage` writes a full snapshot, so an unreadable file
+ * absent from its input would otherwise be silently removed from the store.
+ *
+ * @param repoPath - Absolute path to repository root
+ * @param packageName - Optional package name (resolves the store filename)
+ */
+export function loadStoredPaths(
+  repoPath: string,
+  packageName?: string | null,
+): Set<string> {
+  const filePath = join(
+    getStorageDir(),
+    getStorageFilename(repoPath, packageName),
+  );
+  if (!existsSync(filePath)) {
+    return new Set();
+  }
+
+  try {
+    const data = parse(readFileSync(filePath, "utf-8")) as EnviStore;
+    return new Set(data.files.map((entry) => entry.path));
+  } catch {
+    return new Set();
+  }
+}
+
 export interface SaveToStorageOptions {
   /**
    * If provided, encrypt each file's `env` block before writing. The same key

--- a/src/utils/find-env-files.integration.test.ts
+++ b/src/utils/find-env-files.integration.test.ts
@@ -134,6 +134,48 @@ describe("findEnvFiles (integration)", () => {
     }
   });
 
+  it("skips a real registered worktree even when its .git pointer is missing", async () => {
+    /**
+     * The regression this guards against, exercised against the real git
+     * binary rather than a mocked `git worktree list`. Create a genuine linked
+     * worktree, then delete its `.git` pointer file to reproduce the transient
+     * window during `git worktree add`/`remove` where the marker is gone. The
+     * worktree is still registered in the main repo's `.git/worktrees/`, so
+     * `git worktree list` still reports it and its env file must still be
+     * skipped — the marker probe alone would miss it here.
+     */
+    const worktreePath = join(repoRoot, ".worktrees/live");
+    await execa(
+      "git",
+      ["worktree", "add", "-q", "-b", "live-branch", worktreePath],
+      { cwd: repoRoot },
+    );
+    writeFileSync(join(worktreePath, ".env"), "LIVE_WT=1\n");
+    rmSync(join(worktreePath, ".git"), { force: true });
+
+    try {
+      const result = await findEnvFiles(repoRoot);
+      const all = [...result.files, ...result.excluded];
+
+      expect(all).not.toContain(".worktrees/live/.env");
+      expect(result.skippedNestedVcsRoots).toContain(".worktrees/live/.env");
+    } finally {
+      await execa("git", ["worktree", "remove", "--force", worktreePath], {
+        cwd: repoRoot,
+        reject: false,
+      });
+      await execa("git", ["worktree", "prune"], {
+        cwd: repoRoot,
+        reject: false,
+      });
+      rmSync(join(repoRoot, ".worktrees"), { recursive: true, force: true });
+      await execa("git", ["branch", "-D", "live-branch"], {
+        cwd: repoRoot,
+        reject: false,
+      });
+    }
+  });
+
   it("does not follow symlinks into linked workspace packages", async () => {
     /**
      * pnpm creates symlinks under `node_modules/.pnpm/...` that point back into

--- a/src/utils/find-env-files.test.ts
+++ b/src/utils/find-env-files.test.ts
@@ -1,8 +1,8 @@
 import { consola } from "consola";
 import fg from "fast-glob";
-import { existsSync } from "node:fs";
+import { existsSync, realpathSync } from "node:fs";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { filterGitIgnoredFiles, isGitRepo } from "~/lib/git";
+import { filterGitIgnoredFiles, isGitRepo, listWorktreePaths } from "~/lib/git";
 import { findEnvFiles } from "./find-env-files.js";
 
 vi.mock("fast-glob");
@@ -14,11 +14,21 @@ describe("findEnvFiles", () => {
     vi.clearAllMocks();
     /** Default: no gitignore on disk */
     vi.mocked(existsSync).mockReturnValue(false);
+    /**
+     * The synthetic `/project` paths don't exist on disk, so realpath resolves
+     * to the input unchanged — the same normalization the real code applies to
+     * paths that have no symlinks to resolve.
+     */
+    vi.mocked(realpathSync).mockImplementation(
+      ((path: string) => path) as typeof realpathSync,
+    );
   });
 
   describe("in a git repository", () => {
     beforeEach(() => {
       vi.mocked(isGitRepo).mockReturnValue(true);
+      /** Default: git reports no linked worktrees; individual tests override */
+      vi.mocked(listWorktreePaths).mockResolvedValue([]);
     });
 
     it("returns only files git considers ignored", async () => {
@@ -229,6 +239,61 @@ describe("findEnvFiles", () => {
       const passedToCheckIgnore = vi.mocked(filterGitIgnoredFiles).mock
         .calls[0]?.[1];
       expect(passedToCheckIgnore).toEqual([".env"]);
+    });
+
+    it("skips a registered worktree even when its .git marker is absent", async () => {
+      /**
+       * The regression case: a linked worktree whose `.git` pointer is
+       * momentarily gone (mid add/remove). No marker exists on disk, so the
+       * `existsSync` probe reports nothing nested — but `git worktree list`
+       * still names the worktree, and that alone must skip its files.
+       */
+      vi.mocked(fg).mockResolvedValue([
+        ".env",
+        ".worktrees/feature/.env",
+        ".worktrees/feature/services/api/.dev.vars",
+      ]);
+      /** No `.git` (or any) marker anywhere on disk */
+      vi.mocked(existsSync).mockReturnValue(false);
+      vi.mocked(listWorktreePaths).mockResolvedValue([
+        "/project",
+        "/project/.worktrees/feature",
+      ]);
+      vi.mocked(filterGitIgnoredFiles).mockResolvedValue([".env"]);
+
+      const result = await findEnvFiles("/project");
+
+      expect(result.files).toEqual([".env"]);
+      expect(result.skippedNestedVcsRoots.sort()).toEqual([
+        ".worktrees/feature/.env",
+        ".worktrees/feature/services/api/.dev.vars",
+      ]);
+      /** The main tree entry in the worktree list must not skip its own files */
+      const passedToCheckIgnore = vi.mocked(filterGitIgnoredFiles).mock
+        .calls[0]?.[1];
+      expect(passedToCheckIgnore).toEqual([".env"]);
+    });
+
+    it("does not skip a sibling whose path merely prefixes a worktree path", async () => {
+      /**
+       * `startsWith` on a raw path would match `.worktrees/feature-extra` for a
+       * worktree at `.worktrees/feature`; the trailing-separator prefix guards
+       * against that.
+       */
+      vi.mocked(fg).mockResolvedValue([".worktrees/feature-extra/.env"]);
+      vi.mocked(existsSync).mockReturnValue(false);
+      vi.mocked(listWorktreePaths).mockResolvedValue([
+        "/project",
+        "/project/.worktrees/feature",
+      ]);
+      vi.mocked(filterGitIgnoredFiles).mockResolvedValue([
+        ".worktrees/feature-extra/.env",
+      ]);
+
+      const result = await findEnvFiles("/project");
+
+      expect(result.files).toEqual([".worktrees/feature-extra/.env"]);
+      expect(result.skippedNestedVcsRoots).toEqual([]);
     });
   });
 

--- a/src/utils/find-env-files.ts
+++ b/src/utils/find-env-files.ts
@@ -1,8 +1,8 @@
 import { consola } from "consola";
 import fg from "fast-glob";
-import { existsSync, readFileSync } from "node:fs";
-import { dirname, join, resolve } from "node:path";
-import { filterGitIgnoredFiles, isGitRepo } from "~/lib/git";
+import { existsSync, readFileSync, realpathSync } from "node:fs";
+import { dirname, join, resolve, sep } from "node:path";
+import { filterGitIgnoredFiles, isGitRepo, listWorktreePaths } from "~/lib/git";
 import { VCS_MARKERS } from "./vcs-markers";
 import { getErrorMessage } from "./get-error-message";
 
@@ -123,28 +123,71 @@ function parseGitignoreDirsFallback(repoRoot: string): string[] {
 }
 
 /**
+ * Resolve a path through symlinks so it can be compared to the realpaths `git
+ * worktree list` emits. Falls back to `resolve()` when the path doesn't exist
+ * on disk (a worktree git still lists but whose directory was already removed,
+ * or the synthetic roots in unit tests) — `resolve()` at least normalizes `.` /
+ * `..` and a trailing slash so the comparison stays well-defined.
+ */
+function toRealPath(path: string): string {
+  try {
+    return realpathSync(path);
+  } catch {
+    return resolve(path);
+  }
+}
+
+/**
  * Partition candidate paths into those that live inside a nested VCS root and
  * those that do not.
  *
- * For each candidate, walks upward from its parent directory toward (but not
- * including) the repo root. If any intermediate directory contains a VCS marker
- * (`.git`, `.jj`, `.hg`, `.svn`), the candidate is classified as nested. The
- * repo root itself is never tested — `findRepoRoot` may legitimately return a
- * directory without a marker (when the user confirms the "no VCS found" prompt)
- * and even when a marker is present, the loop terminates before reaching it.
+ * Two signals classify a candidate as nested, and either is sufficient:
  *
- * `repoRoot` is normalized via `resolve()` so a trailing slash on the caller's
- * input does not break the `dir !== repoRoot` loop guard.
+ *  1. **Registered linked worktrees** (`worktreePaths`, from `git worktree
+ *     list`, main tree excluded). Authoritative: a candidate under one of these
+ *     is skipped even when its `.git` pointer file is momentarily absent, which
+ *     is the marker probe's blind spot while git is adding or removing a
+ *     worktree.
+ *  2. **On-disk VCS markers.** Walks upward from the candidate's parent toward
+ *     (but not including) the repo root; if any intermediate directory contains
+ *     a marker (`.git`, `.jj`, `.hg`, `.svn`), the candidate is nested. This is
+ *     the only signal for the nested working trees `git worktree list` doesn't
+ *     know about — submodules, nested clones, and jj/hg/svn checkouts — and the
+ *     fallback when git is unavailable.
  *
- * Per-directory check results are memoized so a deeply nested worktree only
- * pays the existsSync cost once per ancestor.
+ * The repo root itself is never classified nested by either signal:
+ * `findRepoRoot` may legitimately return a directory without a marker (when the
+ * user confirms the "no VCS found" prompt), the main tree is filtered out of
+ * `worktreePaths`, and the marker walk terminates before reaching the root.
+ *
+ * All paths are normalized through `realpathSync` (falling back to `resolve()`
+ * when a path can't be resolved), because `git worktree list` reports fully
+ * symlink-resolved realpaths. Comparing those against a merely `resolve()`d
+ * root would silently fail to match whenever the repo is reached through a
+ * symlink — `/tmp` → `/private/tmp` on macOS, or any symlinked checkout — so
+ * both sides must be resolved the same way. Normalizing also absorbs a trailing
+ * slash on the caller's input, keeping the `dir !== repoRoot` loop guard sound.
+ *
+ * Per-directory marker check results are memoized so a deeply nested worktree
+ * only pays the existsSync cost once per ancestor.
  */
 function partitionNestedVcsRoots(
   repoRoot: string,
   candidates: string[],
+  worktreePaths: string[] = [],
 ): { kept: string[]; skipped: string[] } {
-  const normalizedRoot = resolve(repoRoot);
+  const normalizedRoot = toRealPath(repoRoot);
   const cache = new Map<string, boolean>();
+
+  /**
+   * Linked worktrees as absolute, trailing-separator prefixes (the main tree
+   * dropped), so `absPath.startsWith(prefix)` matches a candidate inside the
+   * worktree without also matching a sibling whose name merely shares a prefix.
+   */
+  const linkedWorktreePrefixes = worktreePaths
+    .map((path) => toRealPath(path))
+    .filter((path) => path !== normalizedRoot)
+    .map((path) => path + sep);
 
   function isNestedVcsRoot(dir: string): boolean {
     const cached = cache.get(dir);
@@ -158,15 +201,23 @@ function partitionNestedVcsRoots(
   const skipped: string[] = [];
 
   for (const relPath of candidates) {
-    let dir = dirname(join(normalizedRoot, relPath));
-    let nested = false;
-    while (dir !== normalizedRoot && dir !== dirname(dir)) {
-      if (isNestedVcsRoot(dir)) {
-        nested = true;
-        break;
+    const absPath = join(normalizedRoot, relPath);
+
+    let nested = linkedWorktreePrefixes.some((prefix) =>
+      absPath.startsWith(prefix),
+    );
+
+    if (!nested) {
+      let dir = dirname(absPath);
+      while (dir !== normalizedRoot && dir !== dirname(dir)) {
+        if (isNestedVcsRoot(dir)) {
+          nested = true;
+          break;
+        }
+        dir = dirname(dir);
       }
-      dir = dirname(dir);
     }
+
     if (nested) {
       skipped.push(relPath);
     } else {
@@ -228,13 +279,21 @@ export async function findEnvFiles(
   });
 
   /**
+   * Ask git for its registered worktrees so a linked worktree is skipped even
+   * when its `.git` pointer is transiently missing (the marker probe's blind
+   * spot). Best-effort and only meaningful inside a git repo; empty otherwise,
+   * leaving marker-only detection in place.
+   */
+  const worktreePaths = inGitRepo ? await listWorktreePaths(repoRoot) : [];
+
+  /**
    * Partition candidates that live inside a nested VCS root (git worktree,
    * submodule, nested clone, jj/hg/svn checkout). These are surfaced separately
    * so the caller can tell the user why they were skipped, instead of silently
    * disappearing.
    */
   const { kept: candidates, skipped: skippedNestedVcsRoots } =
-    partitionNestedVcsRoots(repoRoot, rawCandidates);
+    partitionNestedVcsRoots(repoRoot, rawCandidates, worktreePaths);
 
   if (!inGitRepo) {
     return { files: candidates, excluded: [], skippedNestedVcsRoots };

--- a/src/utils/format-skipped-preview.test.ts
+++ b/src/utils/format-skipped-preview.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+import { formatSkippedPreview } from "./format-skipped-preview";
+
+describe("formatSkippedPreview", () => {
+  it("joins a short list without a suffix", () => {
+    expect(formatSkippedPreview(["a", "b", "c"])).toBe("a, b, c");
+  });
+
+  it("shows the first `max` entries and summarizes the remainder", () => {
+    const paths = ["a", "b", "c", "d", "e", "f", "g"];
+    expect(formatSkippedPreview(paths)).toBe("a, b, c, d, e (...and 2 more)");
+  });
+
+  it("adds no suffix when the list is exactly `max` long", () => {
+    expect(formatSkippedPreview(["a", "b", "c", "d", "e"])).toBe(
+      "a, b, c, d, e",
+    );
+  });
+
+  it("honors a custom `max`", () => {
+    expect(formatSkippedPreview(["a", "b", "c"], 1)).toBe("a (...and 2 more)");
+  });
+
+  it("returns an empty string for an empty list", () => {
+    expect(formatSkippedPreview([])).toBe("");
+  });
+});

--- a/src/utils/format-skipped-preview.ts
+++ b/src/utils/format-skipped-preview.ts
@@ -1,0 +1,15 @@
+/**
+ * Format a truncated preview of a skipped-path list for a one-line log message.
+ *
+ * Joins the first `max` entries and appends a `(...and N more)` suffix when the
+ * list is longer, so the several "Skipped N file(s): ..." lines in `capture`
+ * and `pack` read identically instead of each re-deriving the same slice.
+ *
+ * @param paths - The paths being previewed
+ * @param max - How many to show before summarizing the remainder (default 5)
+ */
+export function formatSkippedPreview(paths: string[], max = 5): string {
+  const preview = paths.slice(0, max).join(", ");
+  const more = paths.length > max ? ` (...and ${paths.length - max} more)` : "";
+  return `${preview}${more}`;
+}

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -2,6 +2,9 @@
 export { findEnvFiles } from "./find-env-files";
 export type { FindEnvFilesResult } from "./find-env-files";
 export { findRepoRoot } from "./find-repo-root";
+export { formatSkippedPreview } from "./format-skipped-preview";
 export { getErrorMessage } from "./get-error-message";
 export { parseEnvFile } from "./parse-env-file";
 export type { EnvObject } from "./parse-env-file";
+export { readEnvFiles } from "./read-env-files";
+export type { ParsedEnvFile, ReadEnvFilesResult } from "./read-env-files";

--- a/src/utils/read-env-files.test.ts
+++ b/src/utils/read-env-files.test.ts
@@ -1,0 +1,72 @@
+import { mkdtempSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { readEnvFiles } from "./read-env-files";
+
+/**
+ * Exercised against a real temp directory rather than a mocked `fs`, because
+ * the whole point of `readEnvFiles` is resilience to real filesystem failure
+ * modes — a path that is gone, a dangling symlink — and a mock that returns a
+ * canned throw would not prove the behavior against the actual `readFileSync`.
+ */
+describe("readEnvFiles", () => {
+  let repoRoot: string;
+
+  beforeAll(() => {
+    repoRoot = mkdtempSync(join(tmpdir(), "envi-read-env-files-"));
+    writeFileSync(join(repoRoot, ".env"), "GOOD=1\n");
+    writeFileSync(join(repoRoot, ".env.local"), "ALSO_GOOD=2\n");
+    /** A symlink whose target never exists — parses to ENOENT on read. */
+    symlinkSync(
+      join(repoRoot, "does-not-exist"),
+      join(repoRoot, ".env.dangling"),
+    );
+  });
+
+  afterAll(() => {
+    rmSync(repoRoot, { recursive: true, force: true });
+  });
+
+  it("parses every readable file and reports none unreadable", () => {
+    const result = readEnvFiles(repoRoot, [".env", ".env.local"]);
+
+    expect(result.unreadable).toEqual([]);
+    expect(result.parsed).toEqual([
+      { path: ".env", env: { GOOD: "1" } },
+      { path: ".env.local", env: { ALSO_GOOD: "2" } },
+    ]);
+  });
+
+  it("skips a path that does not exist instead of throwing", () => {
+    const result = readEnvFiles(repoRoot, [".env", ".env.missing"]);
+
+    expect(result.parsed.map((file) => file.path)).toEqual([".env"]);
+    expect(result.unreadable).toEqual([".env.missing"]);
+  });
+
+  it("skips a dangling symlink instead of throwing", () => {
+    const result = readEnvFiles(repoRoot, [".env.dangling"]);
+
+    expect(result.parsed).toEqual([]);
+    expect(result.unreadable).toEqual([".env.dangling"]);
+  });
+
+  it("keeps the readable files when an unreadable one is interleaved", () => {
+    const result = readEnvFiles(repoRoot, [
+      ".env",
+      ".env.missing",
+      ".env.local",
+    ]);
+
+    expect(result.parsed.map((file) => file.path)).toEqual([
+      ".env",
+      ".env.local",
+    ]);
+    expect(result.unreadable).toEqual([".env.missing"]);
+  });
+
+  it("returns empty results for an empty input list", () => {
+    expect(readEnvFiles(repoRoot, [])).toEqual({ parsed: [], unreadable: [] });
+  });
+});

--- a/src/utils/read-env-files.ts
+++ b/src/utils/read-env-files.ts
@@ -1,0 +1,60 @@
+import { consola } from "consola";
+import { join } from "node:path";
+import { getErrorMessage } from "./get-error-message";
+import { parseEnvFile, type EnvObject } from "./parse-env-file";
+
+/** One successfully parsed env file, keyed by its repo-relative path. */
+export interface ParsedEnvFile {
+  path: string;
+  env: EnvObject;
+}
+
+export interface ReadEnvFilesResult {
+  /** Files that parsed successfully, in input order. */
+  parsed: ParsedEnvFile[];
+  /**
+   * Repo-relative paths that were discovered but could not be read. Surfaced
+   * separately so the command can report a count without the specifics
+   * aborting the run.
+   */
+  unreadable: string[];
+}
+
+/**
+ * Parse each discovered env file, tolerating individual files that cannot be
+ * read.
+ *
+ * `findEnvFiles` returns candidates from a directory glob, but a candidate can
+ * stop being readable between that glob and this read: a dangling symlink, a
+ * permissions change, or — the case this guards against — a git worktree being
+ * torn down by a concurrent process mid-scan, so its files are enumerated and
+ * then deleted before the parse reaches them. A bare `parseEnvFile` throws
+ * `ENOENT` there and takes the whole capture/pack down with it; skipping the
+ * offending file and continuing keeps one unreadable path from aborting a run
+ * that has dozens of perfectly good ones.
+ *
+ * The per-file reason is emitted at debug level rather than swallowed, so a
+ * genuine permissions problem is still recoverable from a verbose run; the
+ * caller reports the count at a more visible level.
+ *
+ * @param repoRoot - Absolute path to the repository root
+ * @param relativePaths - Repo-relative paths to parse
+ */
+export function readEnvFiles(
+  repoRoot: string,
+  relativePaths: string[],
+): ReadEnvFilesResult {
+  const parsed: ParsedEnvFile[] = [];
+  const unreadable: string[] = [];
+
+  for (const path of relativePaths) {
+    try {
+      parsed.push({ path, env: parseEnvFile(join(repoRoot, path)) });
+    } catch (error) {
+      unreadable.push(path);
+      consola.debug(`Could not read ${path}: ${getErrorMessage(error)}`);
+    }
+  }
+
+  return { parsed, unreadable };
+}


### PR DESCRIPTION
`envi capture` crashed with `ENOENT` while scanning a repo that uses git worktrees under `.worktrees/`, and one worktree's env files leaked into the candidate list instead of being skipped. Both symptoms trace to a single situation: a worktree caught **mid-teardown** by a concurrent process — its `.git` pointer file already deleted, its working-tree files still on disk, then removed entirely a moment later.

Two independent defects combined to turn that into a crash.

**1. Worktree detection relied only on an on-disk marker.** `partitionNestedVcsRoots` decided whether a candidate lived inside a worktree purely by probing for a `.git` marker (`existsSync`). A linked worktree whose `.git` pointer is momentarily absent — the window during `git worktree add`/`remove` — has no marker, so its files were not recognized as belonging to another working tree and leaked into the capture set.

This adds `git worktree list` as an authoritative second signal: a candidate under any registered worktree is skipped regardless of the on-disk marker. The marker walk stays as the fallback for the nested trees `git worktree list` doesn't know about (submodules, nested clones, jj/hg/svn) and for when git is unavailable. `git worktree list` reports symlink-resolved realpaths, so both sides of the comparison are normalized through `realpathSync` — without that the prefixes never match when the repo is reached through a symlink (`/tmp` → `/private/tmp` on macOS), which would silently defeat the new signal. A real-git integration test with the worktree's `.git` pointer removed pins the end-to-end behavior.

**2. One unreadable file aborted the whole run.** The parse loop called `parseEnvFile` (a bare `readFileSync`) on every candidate with no guard, so a single path that became unreadable between the glob and the read took the entire capture/pack down. That is fully general — a dangling `.env` symlink anywhere in a repo would do the same — and it is the defect that actually produced the crash: the worktree's files were enumerated, then deleted before the parse reached them.

The parse loop moves into a `readEnvFiles` utility that tolerates a failing file: skip it, record it, continue. `capture` and `pack` report the skipped count and stop only when nothing readable remains. The repeated "Skipped N file(s): …" preview string is factored into `formatSkippedPreview` while both call sites are being touched.

Note that defect 2 is the one that saves the reported case end-to-end: by the time the crash happened the worktree had already been deregistered, so no detection method — marker or `git worktree list` — would classify it as a worktree anymore. Tolerating the unreadable file is what makes that orphaned-directory case a skipped line instead of a crash.

All three changes are covered by unit tests, plus a real-git integration test for the worktree case; `pnpm test`, `pnpm lint`, `pnpm check-types`, and `pnpm build` are green.
